### PR TITLE
Update the scroll into view to use the nearest property as default

### DIFF
--- a/library/src/jsMain/kotlin/com/lightningkite/kiteui/views/RView.commonHtml.js.kt
+++ b/library/src/jsMain/kotlin/com/lightningkite/kiteui/views/RView.commonHtml.js.kt
@@ -268,7 +268,7 @@ fun Align?.logicalPosition(): ScrollLogicalPosition = when (this) {
     Align.End -> ScrollLogicalPosition.END
 
     Align.Stretch -> ScrollLogicalPosition.START
-    null -> ScrollLogicalPosition.START
+    null -> ScrollLogicalPosition.NEAREST
 }
 actual fun RView.nativeScrollIntoView(
     horizontal: Align?,


### PR DESCRIPTION
Update the scroll into view function to use the Nearest property, it was previously missing as an option