### PR TITLE
Update scrollIntoView to use all available options

### DIFF
--- a/library/src/jsMain/kotlin/com/lightningkite/kiteui/views/RView.commonHtml.js.kt
+++ b/library/src/jsMain/kotlin/com/lightningkite/kiteui/views/RView.commonHtml.js.kt
@@ -268,7 +268,7 @@ fun Align?.logicalPosition(): ScrollLogicalPosition = when (this) {
     Align.End -> ScrollLogicalPosition.END
 
     Align.Stretch -> ScrollLogicalPosition.START
-    null -> ScrollLogicalPosition.START
+    null -> ScrollLogicalPosition.NEAREST
 }
 actual fun RView.nativeScrollIntoView(
     horizontal: Align?,


### PR DESCRIPTION
This change just makes the Nearest option available, which is a useful option available in the native scrollIntoView function