### PR TITLE
Fix for improper cropping when switching image sources on Android

### DIFF
--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Image.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Image.android.kt
@@ -138,9 +138,14 @@ actual class ImageView actual constructor(context: RContext) : RView(context) {
             is ImageRaw -> Glide.with(native).load(value.data.data).finish()
             is ImageRemote -> Glide.with(native).load(value.url).finish()
             is ImageResource -> Glide.with(native).load(value.resource).load()
-            is ImageVector -> native.setImageDrawable(PathDrawable(value))
-            null -> native.setImageDrawable(null)
-            else -> TODO()
+            is ImageVector -> run {
+                previousRequestBuilder = null
+                native.setImageDrawable(PathDrawable(value))
+            }
+            null -> run {
+                previousRequestBuilder = null
+                native.setImageDrawable(null)
+            }
         }
     }
 


### PR DESCRIPTION
In Android, we keep a handle on the previous Glide request builder (`previousRequestBuilder`) in order to use Glide to crossfade old images into the new ones (useful for thumbnails). If, however, the `previousRequestBuilder` is associated with an image having a different aspect ratio than the new image, then the new image will be cropped incorrectly due to the behavior of Glide. This PR adds the ability to reset `previousRequestBuilder` by simply setting the image source to null.