### PR TITLE
Implemented file sharing via share sheet on Android

### DIFF
--- a/example-app/src/androidMain/res/xml/filepaths.xml
+++ b/example-app/src/androidMain/res/xml/filepaths.xml
@@ -6,4 +6,5 @@
     <cache-path
             path="videos"
             name="video-cache" />
+    <cache-path name="shared_files" path="." />
 </paths>

--- a/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/ExternalServicesPage.kt
+++ b/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/ExternalServicesPage.kt
@@ -55,7 +55,7 @@ object ExternalServicesPage : Page {
                 }
             }
 
-            row {
+            scrollingHorizontally - row {
                 button {
                     text("Open Map")
                     onClick { ExternalServices.openMap(latitude = 0.0, longitude = 0.0, label = "Null Island") }
@@ -84,6 +84,13 @@ object ExternalServicesPage : Page {
                     text("Share")
                     onClick {
                         ExternalServices.share("Cool Thing", "Check out this cool thing!", "https://github.com/lightningkite/kiteui")
+                    }
+                }
+                button {
+                    text("Share image")
+                    onClick {
+                        val blob = fetch("https://static.wikia.nocookie.net/fzero/images/d/da/Captain_Falcon_SSBU.png").blob()
+                        ExternalServices.share(listOf("Captain_Falcon.png" to blob))
                     }
                 }
             }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/ExternalServices.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/ExternalServices.android.kt
@@ -99,10 +99,9 @@ actual object ExternalServices {
         front: Boolean = false,
         capture: String = MediaStore.ACTION_IMAGE_CAPTURE,
     ): FileReference? = suspendCancellableCoroutine { cont ->
-        val fileProviderAuthority = AndroidAppContext.applicationCtx.packageName + ".fileprovider"
         val file = File(AndroidAppContext.applicationCtx.cacheDir, "images").also { it.mkdirs() }
             .let { File.createTempFile("image", ".jpg", it) }
-            .let { FileProvider.getUriForFile(AndroidAppContext.applicationCtx, fileProviderAuthority, it) }
+            .let { FileProvider.getUriForFile(AndroidAppContext.applicationCtx, AndroidAppContext.fileProviderAuthority, it) }
 
         AndroidAppContext.requestPermissions(android.Manifest.permission.CAMERA) {
             if (!it.accepted) return@requestPermissions cont.resume(null)

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/ExternalServices.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/ExternalServices.android.kt
@@ -190,9 +190,24 @@ actual object ExternalServices {
         return out.toURI()
     }
 
+    private fun <T> List<T>.identity(): T? = first().takeIf { all { it == first() } }
+
     actual suspend fun share(namesToBlobs: List<Pair<String, Blob>>) {
-        // Sharing actual files will likely require configuration of a FileProvider
-        TODO()
+        val files = namesToBlobs.map { it.second.saveToTemporaryFile(it.first) }
+            .map { FileProvider.getUriForFile(AndroidAppContext.applicationCtx, AndroidAppContext.fileProviderAuthority, it) }
+        val commonMimeType = namesToBlobs.map { it.second.type }.identity() ?: "*/*"
+
+        val shareIntent = Intent().apply {
+            if (files.size == 1) {
+                action = Intent.ACTION_SEND
+                putExtra(Intent.EXTRA_STREAM, files.first())
+            } else {
+                action = Intent.ACTION_SEND_MULTIPLE
+                putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(files))
+            }
+            type = commonMimeType
+        }
+        AndroidAppContext.activityCtx?.startActivity(shareIntent)
     }
 
     actual fun share(title: String, message: String?, url: String?) {
@@ -242,5 +257,10 @@ actual object ExternalServices {
                 putExtra(CalendarContract.Events.EVENT_LOCATION, location)
             }
         ) { _, _ -> }
+    }
+
+    private fun Blob.saveToTemporaryFile(name: String): File {
+        val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(type)
+        return File(AndroidAppContext.applicationCtx.cacheDir, "$name.$extension").apply { writeBytes(data) }
     }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/ViewWriter.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/ViewWriter.android.kt
@@ -62,6 +62,7 @@ object AndroidAppContext {
     val executor by lazy {
         ThreadPoolExecutor(1, 1, 10, TimeUnit.SECONDS, ArrayBlockingQueue(10))
     }
+    lateinit var fileProviderAuthority: String
 
     fun startActivityForResult(intent: Intent, options: Bundle? = null, onResult: (Int, Intent?)->Unit) = activityCtx?.startActivityForResult(intent = intent, options = options, onResult = onResult)
     fun requestPermissions(vararg permissions: String, onResult: (KiteUiActivity.PermissionResult)->Unit) = activityCtx?.requestPermissions(permissions = permissions, onResult = onResult)

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/ViewWriter.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/ViewWriter.android.kt
@@ -1,42 +1,23 @@
 package com.lightningkite.kiteui.views
 
-import android.animation.ValueAnimator
 import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
 import android.os.Bundle
-import android.view.View
-import android.view.ViewGroup
-import android.view.ViewParent
-import androidx.core.view.children
 import com.lightningkite.kiteui.KiteUiActivity
-import com.lightningkite.kiteui.models.Action
-import com.lightningkite.kiteui.models.Angle
-import com.lightningkite.kiteui.models.Dimension
-import com.lightningkite.kiteui.models.px
 import com.lightningkite.kiteui.userAgent
-import com.lightningkite.readable.CalculationContext
-import com.lightningkite.readable.Property
-import com.lightningkite.readable.invokeAllSafe
-import com.lightningkite.kiteui.views.direct.DesiredSizeView
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.*
 import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.UserAgent
 import io.ktor.client.plugins.cache.*
 import io.ktor.client.plugins.cache.storage.*
 import io.ktor.client.plugins.websocket.WebSockets
-import io.ktor.http.*
-import io.ktor.util.Platform
 import kotlinx.coroutines.suspendCancellableCoroutine
-import java.lang.RuntimeException
 import java.lang.ref.WeakReference
-import java.util.WeakHashMap
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 object AndroidAppContext {
     lateinit var applicationCtx: Context
@@ -62,7 +43,13 @@ object AndroidAppContext {
     val executor by lazy {
         ThreadPoolExecutor(1, 1, 10, TimeUnit.SECONDS, ArrayBlockingQueue(10))
     }
-    lateinit var fileProviderAuthority: String
+
+    /**
+     * All KiteUI Android apps should have a file provider defined in their manifest with the authority on the file
+     * provider set as follows, based on the Android package name. The file provider is used in the implementation of
+     * several ExternalServices and is referenced using this authority string.
+     */
+    val fileProviderAuthority: String get() = applicationCtx.packageName + ".fileprovider"
 
     fun startActivityForResult(intent: Intent, options: Bundle? = null, onResult: (Int, Intent?)->Unit) = activityCtx?.startActivityForResult(intent = intent, options = options, onResult = onResult)
     fun requestPermissions(vararg permissions: String, onResult: (KiteUiActivity.PermissionResult)->Unit) = activityCtx?.requestPermissions(permissions = permissions, onResult = onResult)


### PR DESCRIPTION
Apparently sharing of blobs in external services was never implemented on Android. This PR adds:

- a configuration variable to `AndroidAppContext` for the `FileProvider` authority (as file providers must be configured on a per-app basis, but it is helpful for KUI functions to be able to use the file provider).
- an Android implementation of `ExternalServices.share()` that uses a `FileProvider` to create a `content://` URI that is used in a share intent