### PR TITLE
iOS bottom sheet popover fix

### DIFF
--- a/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/RootPage.kt
+++ b/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/RootPage.kt
@@ -58,6 +58,7 @@ object RootPage : Page {
                     }
                 } in card
 
+                linkPage { SwapViewPage }
                 linkPage { RichTextButtonPage }
                 linkPage { R2VPPage }
                 linkPage { ProgrammaticLayoutTestPage }

--- a/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/SwapViewPage.kt
+++ b/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/SwapViewPage.kt
@@ -1,0 +1,42 @@
+package com.lightningkite.mppexampleapp.internal
+
+import com.lightningkite.kiteui.Routable
+import com.lightningkite.kiteui.navigation.Page
+import com.lightningkite.kiteui.views.ViewWriter
+import com.lightningkite.kiteui.views.direct.col
+import com.lightningkite.kiteui.views.direct.h1
+import com.lightningkite.kiteui.views.direct.swapView
+import com.lightningkite.kiteui.views.direct.swapping
+import com.lightningkite.readable.sharedProcess
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Routable("swapview")
+object SwapViewPage : Page {
+    override fun ViewWriter.render() = col {
+        val clock = sharedProcess {
+            var tick = 0
+            while (true) {
+                emit(tick++)
+                delay(500)
+            }
+        }
+        val willDelete = swapView {
+            swapping(
+                current = { clock() },
+                views = { tick ->
+                    return@swapping when (tick % 3) {
+                        0 -> h1("1")
+                        1 -> h1("2")
+                        2 -> h1("3")
+                        else -> h1("-")
+                    }
+                }
+            )
+        }
+        launch {
+            delay(5000)
+            removeChild(willDelete)
+        }
+    }
+}

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/RView.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/RView.kt
@@ -60,7 +60,8 @@ abstract class RViewHelper(override val context: RContext) : ViewWriter(), ViewM
     open val cannotBeCovered: Boolean get() = true
 
     abstract var showOnPrint: Boolean
-    private var isShutdown = false
+    var isShutdown = false
+        private set
 
     open var opacity: Double = 1.0
     open var shown: Boolean = true

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/animations.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/animations.ios.kt
@@ -46,7 +46,7 @@ actual fun RView.animateOut(
     if(!animationsEnabled) return
     UIView.animateWithDuration(
         duration = theme.transitionDuration.toDouble(DurationUnit.SECONDS),
-        completion = { done?.invoke() },
+        completion = { if (!isShutdown) done?.invoke() },
         animations = {
             val before = isInAnimationBlock
             isInAnimationBlock = true

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.ios.kt
@@ -66,19 +66,6 @@ actual class CoordinatorFrame actual constructor(context: RContext) : RView(cont
         }
         viewController.kiteUi(context.split()) {
             closeSiblingPopovers()
-            val childCloser = BasicListenable()
-            var closeCurrent = {}
-            var stopListeningToCloser = {}
-            fun internalClose() {
-                stopListeningToCloser()
-                closeCurrent()
-                control.close()
-            }
-            stopListeningToCloser = popoverClosers.addListener {
-                childCloser.invokeAll()
-                internalClose()
-            }
-            popoverClosers = childCloser
 
             beforeNextElementSetup {
                 parent = this@CoordinatorFrame


### PR DESCRIPTION
This PR fixes unexpected behavior when calling `closePopovers()` from inside the ViewWriter of a bottom sheet. Previously, such a call would cause the bottom sheet to close only on iOS. This change causes bottom sheets to not be treated as popovers, like other platforms.