### PR TITLE
iOS bottom sheet popover fix

### DIFF
--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.android.kt
@@ -1,0 +1,7 @@
+package com.lightningkite.kiteui.views
+
+import com.lightningkite.kiteui.views.l2.overlayFrame
+
+actual fun ViewWriter.overlayWriter(body: RView.() -> Unit) {
+    body(overlayFrame ?: return)
+}

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.commonHtml.kt
@@ -1,0 +1,7 @@
+package com.lightningkite.kiteui.views
+
+import com.lightningkite.kiteui.views.l2.overlayFrame
+
+actual fun ViewWriter.overlayWriter(body: RView.() -> Unit) {
+    body(overlayFrame ?: return)
+}

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/RView.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/RView.kt
@@ -333,6 +333,11 @@ abstract class RViewHelper(override val context: RContext) : ViewWriter(), ViewM
         return (handle(myView) ?: ExceptionToMessages.root.handle(myView, exception))
     }
 
+    val shutdownListeners = mutableSetOf<() -> Unit>()
+    fun onShutdown(action: () -> Unit): () -> Unit {
+        shutdownListeners.add(action)
+        return { shutdownListeners.remove(action) }
+    }
 
     // Cleanup Insurance
     open fun shutdown() {
@@ -348,6 +353,7 @@ abstract class RViewHelper(override val context: RContext) : ViewWriter(), ViewM
         }
         if (leakDetection) leakDetect()
         isShutdown = true
+        shutdownListeners.forEach { it() }
     }
 
     open fun leakDetect() {

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.kt
@@ -74,3 +74,5 @@ fun ViewWriter.popoverWriter(close: ()->Unit): ViewWriter {
     writer.popoverClosers = childCloser
     return writer
 }
+
+expect fun ViewWriter.overlayWriter(body: RView.() -> Unit)

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/ExternalServices.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/ExternalServices.kt
@@ -52,7 +52,7 @@ actual object ExternalServices {
     var currentlyPresented: UIViewController? = null
     var currentPresenter: (UIViewController) -> Unit = {}
 
-    private fun present(vc: UIViewController) {
+    fun present(vc: UIViewController) {
         currentlyPresented?.takeIf { it.isViewLoaded() }?.presentViewController(vc, animated = true, completion = null) ?: currentPresenter(vc)
     }
 

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.ios.kt
@@ -19,6 +19,7 @@ actual fun ViewWriter.overlayWriter(body: RView.() -> Unit) {
             this@overlayWriter.overlayFrame?.theme?.let { overlayTheme -> themeChoice = ThemeDerivation { overlayTheme.withoutBack } }
         }
         frame {
+            overlayFrame = this
             body()
         }.also {
             it.children.first().onShutdown {

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.ios.kt
@@ -1,0 +1,30 @@
+package com.lightningkite.kiteui.views
+
+import com.lightningkite.kiteui.ExternalServices
+import com.lightningkite.kiteui.models.ThemeDerivation
+import com.lightningkite.kiteui.views.direct.frame
+import com.lightningkite.kiteui.views.l2.overlayFrame
+import platform.UIKit.UIModalPresentationOverFullScreen
+import platform.UIKit.UIViewController
+
+actual fun ViewWriter.overlayWriter(body: RView.() -> Unit) {
+    val viewController = object : UIViewController(null, null) {
+        override fun viewDidDisappear(animated: Boolean) {
+            super.viewDidDisappear(animated)
+        }
+    }
+    viewController.modalPresentationStyle = UIModalPresentationOverFullScreen
+    viewController.kiteUi(context.split()) {
+        beforeNextElementSetup {
+            this@overlayWriter.overlayFrame?.theme?.let { overlayTheme -> themeChoice = ThemeDerivation { overlayTheme.withoutBack } }
+        }
+        frame {
+            body()
+        }.also {
+            it.children.first().onShutdown {
+                viewController.dismissViewControllerAnimated(true) {  }
+            }
+        }
+    }
+    ExternalServices.present(viewController)
+}

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.ios.kt
@@ -70,6 +70,20 @@ actual class CoordinatorFrame actual constructor(context: RContext) : RView(cont
         }
         viewController.kiteUi(context.split()) {
             closeSiblingPopovers()
+            val childCloser = BasicListenable()
+            var closeCurrent = {}
+            var stopListeningToCloser = {}
+            fun internalClose() {
+                stopListeningToCloser()
+                closeCurrent()
+                control.close()
+            }
+            stopListeningToCloser = popoverClosers.addListener {
+                childCloser.invokeAll()
+                internalClose()
+            }
+            rootPopoverCloser = childCloser
+            popoverClosers = childCloser
 
             beforeNextElementSetup {
                 parent = this@CoordinatorFrame

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.ios.kt
@@ -70,19 +70,6 @@ actual class CoordinatorFrame actual constructor(context: RContext) : RView(cont
         }
         viewController.kiteUi(context.split()) {
             closeSiblingPopovers()
-            val childCloser = BasicListenable()
-            var closeCurrent = {}
-            var stopListeningToCloser = {}
-            fun internalClose() {
-                stopListeningToCloser()
-                closeCurrent()
-                control.close()
-            }
-            stopListeningToCloser = popoverClosers.addListener {
-                childCloser.invokeAll()
-                internalClose()
-            }
-            popoverClosers = childCloser
 
             beforeNextElementSetup {
                 parent = this@CoordinatorFrame


### PR DESCRIPTION
This PR fixes unexpected behavior when calling closePopovers() from inside the ViewWriter of a bottom sheet. Previously, such a call would cause the bottom sheet to close only on iOS. This change causes bottom sheets to not be treated as popovers, like other platforms.