### PR TITLE
overlayWriter fix for iOS

### DIFF
--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/ExternalServices.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/ExternalServices.kt
@@ -53,7 +53,7 @@ actual object ExternalServices {
     var currentPresenter: (UIViewController) -> Unit = {}
 
     fun present(vc: UIViewController) {
-        currentlyPresented?.takeIf { it.isViewLoaded() }?.presentViewController(vc, animated = true, completion = null) ?: currentPresenter(vc)
+        currentlyPresented?.takeIf { it.isBeingPresented() }?.presentViewController(vc, animated = true, completion = null) ?: currentPresenter(vc)
     }
 
     lateinit var rootView: UIView


### PR DESCRIPTION
Fix for trying to present a ViewController from a view that is outside the view hierarchy but still in memory