### PR TITLE
Fix for using popovers within side panels

### DIFF
--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/ViewContextExtensions.kt
@@ -61,7 +61,7 @@ fun ViewWriter.keepPopoverOpen(lifecycle: CoroutineScope) {
     lifecycle.onRemove { popoverKeepOpen-- }
 }
 
-fun ViewWriter.popoverWriter(overlay: ViewWriter = this, close: ()->Unit): ViewWriter {
+fun ViewWriter.popoverWriter(overlay: ViewWriter = this, popoverRoot: Boolean = false, close: ()->Unit): ViewWriter {
     popoverCloser?.invoke()
     popoverCloser = close
     val writer = object : ViewWriter(), CalculationContext by this {
@@ -69,7 +69,7 @@ fun ViewWriter.popoverWriter(overlay: ViewWriter = this, close: ()->Unit): ViewW
         override fun willAddChild(view: RView) = overlay.willAddChild(view)
         override fun addChild(view: RView) = overlay.addChild(view)
     }
-    writer.popoverParent = this@popoverWriter
+    writer.popoverParent = this@popoverWriter.takeIf { !popoverRoot }
     writer.popoverCloser = null
     return writer
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/ExternalServices.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/ExternalServices.ios.kt
@@ -49,10 +49,12 @@ actual object ExternalServices {
     )
 
     var currentlyPresented: UIViewController? = null
+        // Return null if the view controller is not in view (and cannot be used to present another view controller)
+        get() = field?.takeIf { it.viewLoaded && it.view.window != null }
     var currentPresenter: (UIViewController) -> Unit = {}
 
     fun present(vc: UIViewController) {
-        currentlyPresented?.takeIf { it.isBeingPresented() }?.presentViewController(vc, animated = true, completion = null) ?: currentPresenter(vc)
+        currentlyPresented?.presentViewController(vc, animated = true, completion = null) ?: currentPresenter(vc)
     }
 
     lateinit var rootView: UIView

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.ios.kt
@@ -71,7 +71,6 @@ actual class CoordinatorFrame actual constructor(context: RContext) : RView(cont
         popoverCloser?.invoke()
         popoverCloser = { control.close() }
         viewController.kiteUi(context.split()) {
-            popoverParent = this@CoordinatorFrame
             popoverCloser = null
 
             beforeNextElementSetup {
@@ -143,22 +142,25 @@ actual class CoordinatorFrame actual constructor(context: RContext) : RView(cont
                 willRemove = null
             }
         }
-        val popoverWriter = popoverWriter { closePanel() }
+        val popoverWriter = popoverWriter(popoverRoot = true) { closePanel() }
         with(popoverWriter) {
             withoutAnimation {
                 val control = object : SlidingPanelControl {
                     override fun close() {
-                        closePopovers()
+                        this@CoordinatorFrame.closePopovers()
                     }
                 }
-                willRemove = if (ratio == null) {
-                    align(Align.Start, Align.Stretch) - content(control)
-                } else {
-                    row {
-                        gap = 0.px
-                        ignoreInteraction = true
-                        weight(ratio) - content(control)
-                        weight(1f - ratio) - frame { ignoreInteraction = true }
+                willRemove = frame {
+                    overlayFrame = this
+                    if (ratio == null) {
+                        align(Align.Start, Align.Stretch) - content(control)
+                    } else {
+                        row {
+                            gap = 0.px
+                            ignoreInteraction = true
+                            weight(ratio) - content(control)
+                            weight(1f - ratio) - frame { ignoreInteraction = true }
+                        }
                     }
                 }.rView
             }
@@ -181,22 +183,25 @@ actual class CoordinatorFrame actual constructor(context: RContext) : RView(cont
                 willRemove = null
             }
         }
-        val popoverWriter = popoverWriter { closePanel() }
+        val popoverWriter = popoverWriter(popoverRoot = true) { closePanel() }
         with(popoverWriter) {
             withoutAnimation {
                 val control = object : SlidingPanelControl {
                     override fun close() {
-                        closePopovers()
+                        this@CoordinatorFrame.closePopovers()
                     }
                 }
-                willRemove = if (ratio == null) {
-                    align(Align.End, Align.Stretch) - content(control)
-                } else {
-                    row {
-                        gap = 0.px
-                        ignoreInteraction = true
-                        weight(1f - ratio) - frame { ignoreInteraction = true }
-                        weight(ratio) - content(control)
+                willRemove = frame {
+                    overlayFrame = this
+                    if (ratio == null) {
+                        align(Align.End, Align.Stretch) - content(control)
+                    } else {
+                        row {
+                            gap = 0.px
+                            ignoreInteraction = true
+                            weight(1f - ratio) - frame { ignoreInteraction = true }
+                            weight(ratio) - content(control)
+                        }
                     }
                 }.rView
             }


### PR DESCRIPTION
- Bottom sheets and side panels have no `popoverParent`; this is so that `closePopovers()` does not close the sheet/panel itself when called within the sheet/panel
- Side panels now set their own `overlayFrame` so that popovers launched from within side panels have the correct `popoverParent` and `popoverCloser` set
  - Fixes a bug where menu buttons within side panels incorrectly closed the panel and remained open indefinitely