### PR TITLE
UnsatisfiableConstraints error fix

### DIFF
--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/NumberField.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/NumberField.ios.kt
@@ -19,7 +19,9 @@ import platform.objc.sel_registerName
 import com.lightningkite.kiteui.WeakReference
 import com.lightningkite.kiteui.views.direct.TextInput
 import kotlinx.cinterop.ObjCAction
+import kotlinx.cinterop.useContents
 import kotlinx.coroutines.*
+import platform.CoreGraphics.CGRectMake
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 
@@ -41,7 +43,10 @@ actual class NumberInput actual constructor(context: RContext) : RViewWithAction
         backgroundColor = UIColor.clearColor
         keyboardType = UIKeyboardTypeDecimalPad
         delegate = NextFocusDelegateShared
-        inputAccessoryView = UIToolbar().apply {
+
+        // Explicit frame prevents UnsatisfiableConstraints error when automatic constraints are set by the system
+        // https://stackoverflow.com/questions/54284029/uitoolbar-with-uibarbuttonitem-layoutconstraint-issue
+        inputAccessoryView = UIToolbar(CGRectMake(0.0, 0.0, UIScreen.mainScreen.bounds.useContents { size.width }, 35.0)).apply {
             barStyle = UIBarStyleDefault
             setTranslucent(true)
             sizeToFit()

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextArea.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextArea.ios.kt
@@ -5,10 +5,12 @@ import com.lightningkite.kiteui.models.*
 import com.lightningkite.readable.*
 import com.lightningkite.kiteui.views.*
 import kotlinx.cinterop.ObjCAction
+import kotlinx.cinterop.useContents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import platform.CoreGraphics.CGRectMake
 import platform.UIKit.*
 import platform.darwin.NSObject
 import platform.objc.sel_registerName
@@ -33,7 +35,10 @@ actual class TextArea actual constructor(context: RContext) : RViewWithAction(co
         this.delegate = this@TextArea.delegate
         this.textContainerInset = UIEdgeInsetsMake(0.0, 0.0, 0.0, 0.0)
         this.textContainer.lineFragmentPadding = 0.0
-        inputAccessoryView = UIToolbar().apply {
+
+        // Explicit frame prevents UnsatisfiableConstraints error when automatic constraints are set by the system
+        // https://stackoverflow.com/questions/54284029/uitoolbar-with-uibarbuttonitem-layoutconstraint-issue
+        inputAccessoryView = UIToolbar(CGRectMake(0.0, 0.0, UIScreen.mainScreen.bounds.useContents { size.width }, 35.0)).apply {
             barStyle = UIBarStyleDefault
             setTranslucent(true)
             sizeToFit()

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextField.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextField.ios.kt
@@ -4,16 +4,15 @@ package com.lightningkite.kiteui.views.direct
 import com.lightningkite.kiteui.models.*
 import com.lightningkite.kiteui.reactive.Action
 import com.lightningkite.readable.ImmediateWritable
-import com.lightningkite.readable.ReadableState
-import com.lightningkite.readable.Writable
 import com.lightningkite.readable.onRemove
 import com.lightningkite.kiteui.views.*
-import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.ObjCAction
+import kotlinx.cinterop.useContents
 import platform.Foundation.*
 import platform.UIKit.*
 import platform.darwin.NSObject
 import platform.objc.sel_registerName
+import platform.CoreGraphics.CGRectMake
 
 
 actual class TextInput actual constructor(context: RContext) : RViewWithAction(context) {
@@ -37,7 +36,9 @@ actual class TextInput actual constructor(context: RContext) : RViewWithAction(c
         backgroundColor = UIColor.clearColor
         delegate = NextFocusDelegateShared
         if (alwaysToolbar) {
-            inputAccessoryView = UIToolbar().apply {
+            // Explicit frame prevents UnsatisfiableConstraints error when automatic constraints are set by the system
+            // https://stackoverflow.com/questions/54284029/uitoolbar-with-uibarbuttonitem-layoutconstraint-issue
+            inputAccessoryView = UIToolbar(CGRectMake(0.0, 0.0, UIScreen.mainScreen.bounds.useContents { size.width }, 35.0)).apply {
                 barStyle = UIBarStyleDefault
                 setTranslucent(true)
                 sizeToFit()

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextFieldInput.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextFieldInput.kt
@@ -17,7 +17,9 @@ import kotlin.experimental.ExperimentalNativeApi
 class TextFieldInput(calculationContext: CalculationContext): UITextField(CGRectZero.readValue()) {
     val calculationContextWeak = WeakReference(calculationContext)
 
-    val toolbar = UIToolbar().apply {
+    // Explicit frame prevents UnsatisfiableConstraints error when automatic constraints are set by the system
+    // https://stackoverflow.com/questions/54284029/uitoolbar-with-uibarbuttonitem-layoutconstraint-issue
+    val toolbar = UIToolbar(CGRectMake(0.0, 0.0, UIScreen.mainScreen.bounds.useContents { size.width }, 35.0)).apply {
         barStyle = UIBarStyleDefault
         setTranslucent(true)
         sizeToFit()


### PR DESCRIPTION
This fixes a runtime warning that is recovered in most cases. In other words, these changes don't change the UI behavior, but they do prevent the system from flooding the console with UnsatisfiableConstraints warnings. These warnings were due to conflicting constraints when setting a UIToolbar as an `inputAccessoryView`.