### PR TITLE
Swiping support in CoordinatorFrame

### DIFF
--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.android.kt
@@ -8,14 +8,12 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDragHandleView
 import com.google.android.material.sidesheet.SideSheetBehavior
 import com.google.android.material.sidesheet.SideSheetCallback
-import com.lightningkite.kiteui.afterTimeout
 import com.lightningkite.kiteui.models.CardSemantic
 import com.lightningkite.kiteui.models.Color
 import com.lightningkite.kiteui.models.Dimension
 import com.lightningkite.kiteui.models.ThemeAndBack
 import com.lightningkite.kiteui.models.px
 import com.lightningkite.kiteui.models.rem
-import com.lightningkite.kiteui.viewDebugTarget
 import com.lightningkite.kiteui.views.RContext
 import com.lightningkite.kiteui.views.RView
 import com.lightningkite.kiteui.views.ViewModifiable
@@ -32,7 +30,7 @@ import kotlinx.coroutines.launch
 
 actual class CoordinatorFrame actual constructor(context: RContext) : RView(context) {
     override val cannotBeCovered: Boolean get() = false
-    override val native = CoordinatorLayout(context.activity)
+    override val native = CoordinatorLayoutWithGestures(context.activity)
     override fun childTouches(child: RView): Int {
         val p = child.lparams as CoordinatorLayout.LayoutParams
         var total = 0
@@ -57,7 +55,6 @@ actual class CoordinatorFrame actual constructor(context: RContext) : RView(cont
 
     override fun defaultLayoutParams(): ViewGroup.LayoutParams =
         CoordinatorLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
-
 
     actual fun bottomSheet(
         peekSize: Dimension?,
@@ -231,6 +228,14 @@ actual class CoordinatorFrame actual constructor(context: RContext) : RView(cont
             (lparams as? CoordinatorLayout.LayoutParams)?.behavior = b
 
         } - content(control)
+    }
+
+    actual fun onLeftSwipe(action: suspend () -> Unit) {
+        native.onLeftSwipeAction = { launch { action() } }
+    }
+
+    actual fun onRightSwipe(action: suspend () -> Unit) {
+        native.onRightSwipeAction = { launch { action() } }
     }
 }
 

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorLayoutWithGestures.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorLayoutWithGestures.kt
@@ -1,0 +1,42 @@
+package com.lightningkite.kiteui.views.direct
+
+import android.content.Context
+import android.view.GestureDetector
+import android.view.MotionEvent
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import kotlin.math.absoluteValue
+import kotlin.math.atan
+
+class CoordinatorLayoutWithGestures(context: Context) : CoordinatorLayout(context) {
+
+    var onLeftSwipeAction: (() -> Unit)? = null
+    var onRightSwipeAction: (() -> Unit)? = null
+
+    private val gesturesEnabled: Boolean
+        get() = onLeftSwipeAction != null || onRightSwipeAction != null
+
+    private val gestureDetector = GestureDetector(
+        context,
+        object : GestureDetector.SimpleOnGestureListener() {
+            override fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
+                val angle = atan((velocityY / velocityX).toDouble())
+                if (angle.absoluteValue < Math.PI / 10) {
+                    val action = if (velocityX > 0) onRightSwipeAction else onLeftSwipeAction
+                    action?.let {
+                        it.invoke()
+                        return true
+                    }
+                }
+                return false
+            }
+        }
+    )
+
+    override fun onTouchEvent(ev: MotionEvent): Boolean {
+        return gestureDetector.onTouchEvent(ev).takeIf { gesturesEnabled } ?: false
+    }
+
+    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        return gestureDetector.onTouchEvent(ev).takeIf { gesturesEnabled } ?: false
+    }
+}

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TwoWayNestedScrollView.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TwoWayNestedScrollView.kt
@@ -759,9 +759,9 @@ class TwoWayNestedScrollView @JvmOverloads constructor(
                 val xDiff = abs((x - mLastMotionX).toDouble()).toInt()
                 val yDiff = abs((y - mLastMotionY).toDouble()).toInt()
                 val doX = xDiff > mTouchSlop
-                        && (nestedScrollAxes and ViewCompat.SCROLL_AXIS_HORIZONTAL) == 0
+                        && (nestedScrollAxes and ViewCompat.SCROLL_AXIS_HORIZONTAL) == 0 && !lockX
                 val doY = yDiff > mTouchSlop
-                        && (nestedScrollAxes and ViewCompat.SCROLL_AXIS_VERTICAL) == 0
+                        && (nestedScrollAxes and ViewCompat.SCROLL_AXIS_VERTICAL) == 0 && !lockY
                 if (doX || doY) {
                     mIsBeingDragged = true
                     mLastMotionX = x

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.commonHtml.kt
@@ -140,6 +140,14 @@ actual class CoordinatorFrame actual constructor(context: RContext) : RView(cont
             }.rView
         }
     }
+
+    actual fun onLeftSwipe(action: suspend () -> Unit) {
+
+    }
+
+    actual fun onRightSwipe(action: suspend () -> Unit) {
+
+    }
 }
 
 

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.kt
@@ -28,6 +28,8 @@ expect class CoordinatorFrame(context: RContext) : RView {
         blockBehind: Boolean = false,
         content: ViewWriter.(control: SlidingPanelControl) -> ViewModifiable
     )
+    fun onLeftSwipe(action: suspend () -> Unit)
+    fun onRightSwipe(action: suspend () -> Unit)
 }
 
 enum class BottomSheetState {

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CoordinatorFrame.ios.kt
@@ -4,34 +4,29 @@ import com.lightningkite.kiteui.ExternalServices
 import com.lightningkite.kiteui.models.Align
 import com.lightningkite.kiteui.models.ClickableSemantic
 import com.lightningkite.kiteui.models.Dimension
-import com.lightningkite.kiteui.models.DisabledSemantic
 import com.lightningkite.kiteui.models.DownSemantic
 import com.lightningkite.kiteui.models.FocusSemantic
-import com.lightningkite.kiteui.models.Icon
 import com.lightningkite.kiteui.models.ScreenTransition
 import com.lightningkite.kiteui.models.ScreenTransitions
 import com.lightningkite.kiteui.models.ThemeAndBack
 import com.lightningkite.kiteui.models.px
 import com.lightningkite.kiteui.views.*
-import com.lightningkite.kiteui.views.l2.icon
 import com.lightningkite.kiteui.views.l2.overlayFrame
 import com.lightningkite.readable.Property
 import com.lightningkite.readable.Writable
 import com.lightningkite.readable.invoke
 import com.lightningkite.readable.onRemove
-import com.lightningkite.readable.reactive
 import kotlinx.coroutines.launch
-import platform.UIKit.UISheetPresentationControllerDetentIdentifier
 import platform.UIKit.UISheetPresentationController
-import platform.UIKit.UIView
 import platform.UIKit.UIViewController
 import com.lightningkite.kiteui.objc.presentationController
 import com.lightningkite.kiteui.views.popoverWriter
-import com.lightningkite.readable.BasicListenable
+import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.delay
-import platform.UIKit.UIModalPresentationPageSheet
-import platform.UIKit.UISheetPresentationControllerDetent
+import platform.UIKit.*
+import platform.darwin.NSObject
+import platform.objc.sel_registerName
 
 private var ViewWriter.bottomSheetState: Writable<BottomSheetState>? by rContextAddon<Writable<BottomSheetState>?>(null)
 
@@ -46,6 +41,13 @@ actual class CoordinatorFrame actual constructor(context: RContext) : RView(cont
             Side.Bottom -> child.native.extensionVerticalAlign?.touchesEnd != false
         }
     }
+
+    // The system only keeps weak references to the following objects, so we must keep our own references for the
+    // lifetime of the view
+    private var leftSwipeTarget: NSObject? = null
+    private var leftSwipeRecognizer: UISwipeGestureRecognizer? = null
+    private var rightSwipeTarget: NSObject? = null
+    private var rightSwipeRecognizer: UISwipeGestureRecognizer? = null
 
     actual fun bottomSheet(
         peekSize: Dimension?,
@@ -207,6 +209,34 @@ actual class CoordinatorFrame actual constructor(context: RContext) : RView(cont
             }
         }
         willRemove?.animateIn(transition.forward)
+    }
+
+    actual fun onLeftSwipe(action: suspend () -> Unit) {
+        leftSwipeTarget = object : NSObject() {
+            @ObjCAction
+            fun handleLeftSwipe(sender: UISwipeGestureRecognizer) {
+                launch { action() }
+            }
+        }
+        leftSwipeRecognizer?.let(native::removeGestureRecognizer)
+        leftSwipeRecognizer = UISwipeGestureRecognizer(leftSwipeTarget, sel_registerName("handleLeftSwipe:")).apply {
+            direction = UISwipeGestureRecognizerDirectionLeft
+        }.also(native::addGestureRecognizer)
+        native.userInteractionEnabled = true
+    }
+
+    actual fun onRightSwipe(action: suspend () -> Unit) {
+        rightSwipeTarget = object : NSObject() {
+            @ObjCAction
+            fun handleRightSwipe(sender: UISwipeGestureRecognizer) {
+                launch { action() }
+            }
+        }
+        rightSwipeRecognizer?.let(native::removeGestureRecognizer)
+        rightSwipeRecognizer = UISwipeGestureRecognizer(rightSwipeTarget, sel_registerName("handleRightSwipe:")).apply {
+            direction = UISwipeGestureRecognizerDirectionRight
+        }.also(native::addGestureRecognizer)
+        native.userInteractionEnabled = true
     }
 }
 


### PR DESCRIPTION
- Left and right swipe touch gesture support for `CoordinatorFrame`
- Bugfix for Android's `TwoWayNestedScrollView` that prevents scroll views from greedily consuming touch events in a direction in which the scroll view is locked (this fix in turn prevents contention with the `GestureRecognizer` for the newly introduced swipe listeners)