### PR TITLE
Zoom centers on double-tap on iOS

### DIFF
--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/utils/cgRect.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/utils/cgRect.kt
@@ -6,8 +6,32 @@ import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGRect
+import platform.CoreGraphics.CGPoint
+import platform.CoreGraphics.CGPointMake
 
 val CValue<CGRect>.local: Rect
     get() = useContents {
         return Rect(origin.x, origin.y, origin.x + size.width, origin.y + size.height)
     }
+
+typealias LocalPoint = Pair<Double, Double>
+
+val CValue<CGPoint>.local: LocalPoint
+    get() = useContents {
+        return x to y
+    }
+
+operator fun LocalPoint.plus(other: LocalPoint) : LocalPoint =
+    first + other.first to second + other.second
+
+operator fun LocalPoint.minus(other: LocalPoint) : LocalPoint =
+    first - other.first to second - other.second
+
+operator fun LocalPoint.times(other: Double) : LocalPoint =
+    first * other to second * other
+
+operator fun LocalPoint.div(other: Int) : LocalPoint =
+    first / other to second / other
+
+val LocalPoint.cg: CValue<CGPoint>
+    get() = CGPointMake(first, second)

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.ios.kt
@@ -9,6 +9,12 @@ import com.lightningkite.kiteui.models.div
 import com.lightningkite.kiteui.models.plus
 import com.lightningkite.kiteui.views.*
 import com.lightningkite.kiteui.objc.*
+import com.lightningkite.kiteui.utils.cg
+import com.lightningkite.kiteui.utils.div
+import com.lightningkite.kiteui.utils.local
+import com.lightningkite.kiteui.utils.minus
+import com.lightningkite.kiteui.utils.plus
+import com.lightningkite.kiteui.utils.times
 import kotlinx.cinterop.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -163,16 +169,29 @@ actual class RawImageViewZoomable actual constructor(
     val doubleTapTarget: NSObject = object: NSObject() {
         @ObjCAction
         fun handleDoubleTap(sender: UITapGestureRecognizer) {
-            println("Doubletap")
+            if (sender.state != UIGestureRecognizerStateEnded) return
+
             val midZoom = (native.maximumZoomScale - native.minimumZoomScale) / 2.0 + native.minimumZoomScale
             if (native.zoomScale < midZoom) {
-                native.setZoomScale(native.maximumZoomScale, true)
+                val touch = sender.locationInView(native).local
+                val origin = native.frame.useContents { size.width / 2 to size.height / 2 }
+
+                val offset = touch - origin
+                val scaledOffset = (native.frame.useContents { size.width to size.height } * (native.maximumZoomScale - 1)) / 2
+                val newContentOffset = scaledOffset + offset * native.maximumZoomScale
+
+                UIView.animateWithDuration(0.3) {
+                    native.setZoomScale(native.maximumZoomScale)
+                    native.setContentOffset(newContentOffset.cg)
+                }
             } else {
                 native.setZoomScale(native.minimumZoomScale, true)
             }
         }
     }
-    val doubleTapRecognizer = UITapGestureRecognizer(doubleTapTarget, sel_registerName("handleDoubleTap:"))
+    val doubleTapRecognizer = UITapGestureRecognizer(doubleTapTarget, sel_registerName("handleDoubleTap:")).apply {
+        numberOfTapsRequired = 2UL
+    }
     override val native = UIScrollView(CGRectZero.readValue()).apply {
         addGestureRecognizer(doubleTapRecognizer)
         showsHorizontalScrollIndicator = false
@@ -182,7 +201,6 @@ actual class RawImageViewZoomable actual constructor(
         maximumZoomScale = 4.0
         showsHorizontalScrollIndicator = false
         showsVerticalScrollIndicator = false
-
     }
     val imageView = UIImageView(CGRectZero.readValue()).apply {
         contentMode = when (scaleType) {
@@ -206,8 +224,6 @@ actual class RawImageViewZoomable actual constructor(
         }
     }
     init {
-        val doubleTapRecognizer = UITapGestureRecognizer(this, sel_registerName("handleDoubleTap:"))
-        doubleTapRecognizer.numberOfTapsRequired = 2UL
         imageView.translatesAutoresizingMaskIntoConstraints = false
         native.delegate = dg
         native.addSubview(imageView)


### PR DESCRIPTION
When using `RawImageViewZoomable`, double-tap to zoom now anchors the zoom according to where you have tapped (zooming was previously centered in the image). This PR also includes a fix for single taps erroneously triggering the zoom.