### PR TITLE
Fix for scrolling stutter on iOS

### DIFF
--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.android.kt
@@ -45,6 +45,7 @@ actual class RawImageView actual constructor(
     source: ImageSource,
     description: String,
     scaleType: ImageScaleType,
+    resizeWhenLoaded: Boolean,
 ) : RawImageViewLike(context, source, description, scaleType) {
     private val _state = RawReadable<Unit>()
     actual override val state: Readable<Unit> = _state

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.commonHtml.kt
@@ -47,6 +47,7 @@ actual class RawImageView actual constructor(
     source: ImageSource,
     description: String,
     scaleType: ImageScaleType,
+    resizeWhenLoaded: Boolean,
 ) : RawImageViewLike(context, source, description, scaleType) {
     override val cannotBeCovered: Boolean get() = false
 

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/ImageView.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/ImageView.kt
@@ -95,7 +95,7 @@ class ImageView(viewWriter: ViewWriter) : ViewModifiable {
                     with(rView) {
                         for (imageSource in it.sources) {
                             ThemeDerivation { if(rView.themeAndBack.drawBackground) it.withBack else it.withoutBack }.onNext
-                            add(rawImage(imageSource, it.description ?: "", it.scaleType) {
+                            add(rawImage(imageSource, it.description ?: "", it.scaleType, false) {
                                 themeTakeNonCascadingFromParent = true
                                 themeChoice
                                 opacity = 0.0

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.kt
@@ -19,6 +19,7 @@ expect class RawImageView(
     source: ImageSource,
     description: String,
     scaleType: ImageScaleType,
+    resizeWhenLoaded: Boolean = true,
 ) : RawImageViewLike {
     override val state: Readable<Unit>
 }

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/dsl.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/dsl.kt
@@ -89,9 +89,9 @@ inline fun ViewWriter.zoomableImage(setup: ZoomableImageView.() -> Unit = {}): Z
 }
 @OptIn(ExperimentalContracts::class)
 @ViewDsl
-inline fun ViewWriter.rawImage(source: ImageSource, description: String, scaleType: ImageScaleType, setup: RawImageView.() -> Unit = {}): RawImageView {
+inline fun ViewWriter.rawImage(source: ImageSource, description: String, scaleType: ImageScaleType, resizeWhenLoaded: Boolean = true, setup: RawImageView.() -> Unit = {}): RawImageView {
     contract { callsInPlace(setup, InvocationKind.EXACTLY_ONCE) }
-    return write(RawImageView(context, source, description, scaleType) , setup)
+    return write(RawImageView(context, source, description, scaleType, resizeWhenLoaded) , setup)
 }
 @OptIn(ExperimentalContracts::class)
 @ViewDsl

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.ios.kt
@@ -103,6 +103,7 @@ actual class RawImageView actual constructor(
     source: ImageSource,
     description: String,
     scaleType: ImageScaleType,
+    resizeWhenLoaded: Boolean,
 ) : RawImageViewLike(context, source, description, scaleType) {
     private val _state = RawReadable<Unit>()
     actual override val state: Readable<Unit> = _state
@@ -125,7 +126,7 @@ actual class RawImageView actual constructor(
                 val img = load(source, native.bounds.useContents { Size(size.width, size.height) })
                 _state.state = ReadableState(Unit)
                 native.image = img
-                native.informParentOfSizeChange()
+                if (resizeWhenLoaded) native.informParentOfSizeChange()
             } catch(e: Exception) {
                 _state.state = ReadableState.exception(e)
             }


### PR DESCRIPTION
Re-layouts that occur during any kind of system scroll animation cause the scroll to stutter noticeably. This scenario occurs when any kind of `ScrollLayout` includes a `RawImageView` that loads during a scroll animation (notably including recyclers with images). `ImageView` shouldn't need to force a re-layout if it is simply loading in a higher-resolution image (in all cases I can think of, the size of the view should not change). This PR **entirely disables re-layouts on image load** for `ImageView` in iOS, which **will likely cause problems** for uses where size constraints are not set explicitly. This PR is more of a stub for an unsolved issue.