### PR TITLE
iOS hit test fixes

### DIFF
--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollView.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollView.commonHtml.kt
@@ -29,7 +29,7 @@ expect class ScrollingBehaviorImpl constructor(
 
      override var scrollSnapStop: Boolean
 
-
+     override var ignoreInteraction: Boolean
 
      override fun scrollTo(left: Double, top: Double, animated: Boolean)
 

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollingBehaviors.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollingBehaviors.kt
@@ -17,6 +17,7 @@ interface ScrollingBehaviors {
     var scrollSnapStop: Boolean
     fun scrollTo(left: Double, top: Double, animated: Boolean)
     fun scrollTo(element: RView, horizontal: Align, vertical: Align, animated: Boolean)
+    var ignoreInteraction: Boolean
 
     /**
      * Should not interrupt animations.

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/l2/Recycler2.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/l2/Recycler2.kt
@@ -109,12 +109,14 @@ class Recycler2(
                     ignoreInteraction = Platform.current != Platform.Web
                 } - programmatic {
                     fakeScrollContent = this
+                    ignoreInteraction = Platform.current != Platform.Web
                     ThemeDerivation {
                         it.copy(
                             id = "scrollindicator",
                             background = it.foreground.applyAlpha(0.5f)
                         ).withBack
                     }.onNext - unpadded - frame {
+                        ignoreInteraction = Platform.current != Platform.Web
                         fakeScrollIndicator = this
                         opacity = 0.0
                     }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/FrameLayoutExtensions.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/FrameLayoutExtensions.kt
@@ -147,7 +147,7 @@ fun UIView.frameLayoutHitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIVi
         }
     }
 //    println("$this give up: $userInteractionEnabled")
-    return if(userInteractionEnabled) this else null
+    return if (extensionIgnoreInteraction != true) this else null
 }
 
 

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ProgrammaticLayout.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ProgrammaticLayout.ios.kt
@@ -12,9 +12,11 @@ import com.lightningkite.kiteui.views.informParentOfSizeChangeDueToChild
 import com.lightningkite.kiteui.views.layoutSubviewsAndLayers
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.useContents
+import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGSize
 import platform.CoreGraphics.CGSizeMake
+import platform.UIKit.UIEvent
 import platform.UIKit.UIView
 import kotlin.experimental.ExperimentalNativeApi
 
@@ -137,5 +139,9 @@ class NProgrammaticLayout: UIView(CGRectMake(0.0, 0.0, 0.0, 0.0)), UIViewWithSiz
             }, inProgress, bounds.useContents { Size(size.width, size.height) })
             inLayout = false
         }
+    }
+
+    override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? {
+        return frameLayoutHitTest(point, withEvent)
     }
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollLayout.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollLayout.kt
@@ -167,4 +167,8 @@ class ScrollLayout : UIScrollView(CGRectZero.readValue()), UIViewWithSizeOverrid
             lastReportedSize = mySizeWithoutPadding
         }
     }
+
+    override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? {
+        return frameLayoutHitTest(point, withEvent)
+    }
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollView.ios.kt
@@ -7,6 +7,7 @@ import com.lightningkite.kiteui.views.RContext
 import com.lightningkite.kiteui.views.RView
 import com.lightningkite.kiteui.views.RViewWrapper
 import com.lightningkite.kiteui.views.extensionHorizontalAlign
+import com.lightningkite.kiteui.views.extensionIgnoreInteraction
 import com.lightningkite.kiteui.views.extensionVerticalAlign
 import kotlinx.cinterop.*
 import platform.CoreGraphics.CGPoint
@@ -159,6 +160,13 @@ class ScrollView(
             field = value
             scroller.showsHorizontalScrollIndicator = value
             scroller.showsVerticalScrollIndicator = value
+        }
+    override var ignoreInteraction: Boolean
+        get() = super.ignoreInteraction
+        set(value) {
+            super.ignoreInteraction = value
+            scroller.extensionIgnoreInteraction = value
+            scroller.scrollEnabled = !value
         }
     override val viewport: Readable<Rect> = (sizeChange + scroll).lensListenable {
         val (ox, oy) = scroller.contentOffset.useContents { x to y }

--- a/library/src/jsMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollView.commonHtml.js.kt
+++ b/library/src/jsMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollView.commonHtml.js.kt
@@ -137,6 +137,10 @@ actual class ScrollingBehaviorImpl actual constructor(
             native.setStyleProperty("scroll-snap-stop", if (value) "always" else "normal")
         }
 
+    actual override var ignoreInteraction: Boolean
+        get() = throw UnsupportedOperationException("Ignoring ScrollView interaction is not supported for web targets")
+        set(value) {}
+
     actual override fun scrollTo(left: Double, top: Double, animated: Boolean) {
         if (viewDebugTarget == on) println("ScrollView.scrollTo($left, $top, $animated)")
         disableSnapTemporarily()

--- a/library/src/jvmMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollView.commonHtml.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/lightningkite/kiteui/views/direct/ScrollView.commonHtml.jvm.kt
@@ -1,10 +1,10 @@
 package com.lightningkite.kiteui.views.direct
 
-import com.lightningkite.kiteui.afterTimeout
 import com.lightningkite.kiteui.models.Align
 import com.lightningkite.kiteui.models.Rect
 import com.lightningkite.readable.*
 import com.lightningkite.kiteui.views.*
+import kotlin.UnsupportedOperationException
 
 actual class ScrollingBehaviorImpl actual constructor(
     val on: RView,
@@ -55,6 +55,10 @@ actual class ScrollingBehaviorImpl actual constructor(
             field = value
             native.setStyleProperty("scroll-snap-stop", if(value) "always" else "normal")
         }
+    actual override var ignoreInteraction: Boolean
+        get() = throw UnsupportedOperationException("Ignoring ScrollView interaction is not supported for web targets")
+        set(value) {}
+
     actual override fun scrollTo(left: Double, top: Double, animated: Boolean) {
     }
     actual override fun scrollTo(element: RView, horizontal: Align, vertical: Align, animated: Boolean) {


### PR DESCRIPTION
This PR fixes cases where views with `ignoreInteraction` set would incorrectly handle touches. Notably, this fixes an issue where recycler view scrollbars intercepted touches on mobile.