### PR TITLE
Line clamp

### DIFF
--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/ExternalServices.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/ExternalServices.android.kt
@@ -172,9 +172,6 @@ private fun downloadContinued(name: String, url: String) {
         )
     request.allowScanningByMediaScanner()
     (AndroidAppContext.applicationCtx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager).enqueue(request) // 8.
-    Toast.makeText( // 9.
-        AndroidAppContext.activityCtx!!, "Download started", Toast.LENGTH_SHORT
-    ).show()
 }
 
 @SuppressLint("MissingPermission")
@@ -214,7 +211,6 @@ actual suspend fun RContext.download(name: String, blob: Blob, preferredDestinat
         contentValues.clear()
         contentValues.put(MediaStore.Downloads.IS_PENDING, 0)
         resolver.update(uri, contentValues, null, null)
-        Toast.makeText(AndroidAppContext.activityCtx!!, "Download complete", Toast.LENGTH_SHORT).show()
     }
 }
 

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.android.kt
@@ -78,7 +78,11 @@ actual class TextView actual constructor(context: RContext) :
         }
     actual var lineClamp: Int? = null
         set(value) {
-            // TODO
+            field = value
+            value?.let {
+                native.maxLines = value
+                native.ellipsize = TextUtils.TruncateAt.END
+            }
         }
     override fun applyTheme(theme: ThemeAndBack) { super.applyTheme(theme); val theme = theme.theme
         debugPrint {

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.android.kt
@@ -76,6 +76,10 @@ actual class TextView actual constructor(context: RContext) :
                 }
             }
         }
+    actual var lineClamp: Int? = null
+        set(value) {
+            // TODO
+        }
     override fun applyTheme(theme: ThemeAndBack) { super.applyTheme(theme); val theme = theme.theme
         debugPrint {
             "native.setTextColor: ${theme.id} ${theme.foreground}"

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.commonHtml.kt
@@ -46,11 +46,10 @@ actual class TextView actual constructor(context: RContext) : RView(context) {
         set(value) {
             native.setStyleProperty("word-break", if(value == WordBreak.BreakAll) "break-all" else "normal")
         }
-    actual var lineClamp: Int?
-        get() = TODO("Not yet implemented")
+    actual var lineClamp: Int? = null
         set(value) {
+            field = value
             value?.let {
-                native.setStyleProperty("background-color", "lightgreen")
                 native.setStyleProperty("display", "-webkit-box")
                 native.setStyleProperty("line-clamp", "$it")
                 native.setStyleProperty("-webkit-line-clamp", "$it")

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.commonHtml.kt
@@ -46,6 +46,19 @@ actual class TextView actual constructor(context: RContext) : RView(context) {
         set(value) {
             native.setStyleProperty("word-break", if(value == WordBreak.BreakAll) "break-all" else "normal")
         }
+    actual var lineClamp: Int?
+        get() = TODO("Not yet implemented")
+        set(value) {
+            value?.let {
+                native.setStyleProperty("background-color", "lightgreen")
+                native.setStyleProperty("display", "-webkit-box")
+                native.setStyleProperty("line-clamp", "$it")
+                native.setStyleProperty("-webkit-line-clamp", "$it")
+                native.setStyleProperty("-webkit-box-orient", "vertical")
+                native.setStyleProperty("overflow", "hidden")
+                native.setStyleProperty("text-overflow", "ellipsis")
+            }
+        }
     actual fun setBasicHtmlContent(html: String) {
         native.style.whiteSpace = "pre-line"
         native.innerHtmlUnsafe = html.parseMPNodes().onEach { it.secure() }.joinToString(" ")

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.kt
@@ -19,5 +19,6 @@ expect class TextView(context: RContext) : RView {
     var ellipsis: Boolean
     var wraps: Boolean
     var wordBreak: WordBreak
+    var lineClamp: Int?
     fun setBasicHtmlContent(html: String)
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.ios.kt
@@ -119,6 +119,10 @@ actual class TextView actual constructor(context: RContext) : RView(context) {
                 WordBreak.BreakAll -> NSLineBreakByCharWrapping
             }
         }
+    actual var lineClamp: Int? = null
+        set(value) {
+            // TODO
+        }
 
     override fun applyTheme(theme: ThemeAndBack) {
         super.applyTheme(theme);

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.ios.kt
@@ -121,7 +121,11 @@ actual class TextView actual constructor(context: RContext) : RView(context) {
         }
     actual var lineClamp: Int? = null
         set(value) {
-            // TODO
+            field = value
+            label.numberOfLines = value ?: 0
+            if (value != null && label.lineBreakMode != NSLineBreakByTruncatingTail) {
+                label.lineBreakMode = NSLineBreakByTruncatingTail
+            }
         }
 
     override fun applyTheme(theme: ThemeAndBack) {


### PR DESCRIPTION
Add "lineClamp" to TextView, making it so you can specify how many lines the text can use before being cut off


**This has NOT been tested on iOS yet**, but I've tested it on Android & Web

Also, remove Android automatic Toast from ExternalServices.download.