### PR TITLE
scrollable text area - web

### DIFF
--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/KiteUiCss.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/KiteUiCss.kt
@@ -604,6 +604,7 @@ class KiteUiCss(val dynamicCss: DynamicCss) {
               /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
               display: grid;
               position: relative;
+              overflow-y: scroll;
             }
             .textarea-container::after {
               /* Note the weird space! Needed to preventy jumpy behavior */


### PR DESCRIPTION
When text area has a max height, it should be scrollable. Already works in Android (and probably iOS)