### PR TITLE
allow target attribute for 'a' tag

### DIFF
--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/dom/microparse.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/dom/microparse.kt
@@ -37,7 +37,8 @@ sealed interface MPNode {
             "br",
         )
         val okAttrs = setOf(
-            "href"
+            "href",
+            "target",
         )
     }
 


### PR DESCRIPTION
this allows links to open in a new tab
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#target