### PR TITLE
recycler filter fix

### DIFF
--- a/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/RecyclerFilterTestPage.kt
+++ b/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/RecyclerFilterTestPage.kt
@@ -1,0 +1,50 @@
+package com.lightningkite.mppexampleapp.internal
+
+import com.lightningkite.kiteui.Routable
+import com.lightningkite.kiteui.models.ListSemantic
+import com.lightningkite.kiteui.navigation.Page
+import com.lightningkite.kiteui.views.ViewModifiable
+import com.lightningkite.kiteui.views.ViewWriter
+import com.lightningkite.kiteui.views.direct.col
+import com.lightningkite.kiteui.views.direct.recyclerView
+import com.lightningkite.kiteui.views.direct.row
+import com.lightningkite.kiteui.views.direct.text
+import com.lightningkite.kiteui.views.direct.textInput
+import com.lightningkite.kiteui.views.expanding
+import com.lightningkite.kiteui.views.fieldTheme
+import com.lightningkite.kiteui.views.l2.children
+import com.lightningkite.readable.Property
+import com.lightningkite.readable.shared
+
+@Routable("recycler-filter-test")
+object RecyclerFilterTestPage : Page {
+    val searchText = Property("")
+
+    override fun ViewWriter.render(): ViewModifiable = col {
+
+        fieldTheme - row {
+            expanding - textInput {
+                hint = "Search"
+                content bind searchText
+            }
+        }
+
+        expanding - col {
+            expanding - ListSemantic.onNext - recyclerView {
+                children(
+                    items = shared {
+                        listOf("asdf", "asdf1", "qwerty").filter {
+                            it.contains(searchText().lowercase())
+                        }
+                    },
+                    id = { it },
+                    render = {
+                        text {
+                            ::content { it() }
+                        }
+                    }
+                )
+            }
+        }
+    }
+}

--- a/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/RootPage.kt
+++ b/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/RootPage.kt
@@ -20,6 +20,7 @@ import com.lightningkite.kiteui.views.direct.scrolling
 import com.lightningkite.kiteui.views.direct.separator
 import com.lightningkite.kiteui.views.direct.text
 import com.lightningkite.kiteui.views.direct.weight
+import com.lightningkite.kiteui.views.expanding
 import com.lightningkite.kiteui.views.l2.icon
 import com.lightningkite.mppexampleapp.docs.VideoElementPage
 import com.lightningkite.mppexampleapp.docs.ViewPagerElementPage
@@ -39,16 +40,15 @@ object RootPage : Page {
             }
             ListSemantic.onNext - col {
 
-                fun ViewWriter.linkPage(screen: () -> Page) = link {
+                fun ViewWriter.linkPage(screen: () -> Page) = card - link {
                     to = screen
                     row {
-                        text {
+                        expanding - text {
                             ::content{ screen().title() }
-//                            content  = screen.toString()
-                        } in weight(1f)
+                        }
                         icon(Icon.Companion.chevronRight, "Open")
                     }
-                } in card
+                }
 
                 linkPage { RowWrappingPage }
                 linkPage { CoveringTestPage }
@@ -66,9 +66,10 @@ object RootPage : Page {
                 linkPage { LeakCheckerPage }
                 linkPage { ExperimentPage }
                 linkPage { Recycler2TestPage }
-                linkPage { AudioPage }
+                linkPage { RecyclerFilterTestPage }
                 linkPage { HorizontalRecyclerViewPage }
                 linkPage { InfiniteImagesPage }
+                linkPage { AudioPage }
                 linkPage { PlatformSpecificPage }
                 linkPage { VideoElementPage }
                 linkPage { ViewPagerElementPage }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ProgrammaticLayout.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ProgrammaticLayout.ios.kt
@@ -121,6 +121,7 @@ class NProgrammaticLayout: UIView(CGRectMake(0.0, 0.0, 0.0, 0.0)), UIViewWithSiz
     fun invalidateLayout() {
         if(inLayout) return
         myInvalidated = true
+        informParentOfSizeChangeDueToChild()
         setNeedsLayout()
     }
 


### PR DESCRIPTION
on iOS, when the children of a recycler view is changed/updated, the parent element needs to recalculate its size. Otherwise, the list will not always render all of the elements