### PR TITLE
clips to bounds for images

### DIFF
--- a/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/ImageTestPage.kt
+++ b/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/ImageTestPage.kt
@@ -1,18 +1,14 @@
 package com.lightningkite.mppexampleapp.internal
 
 import com.lightningkite.kiteui.*
+import com.lightningkite.kiteui.models.ImageScaleType
 import com.lightningkite.kiteui.models.rem
 import com.lightningkite.kiteui.navigation.Page
-import com.lightningkite.kiteui.reactive.*
 import com.lightningkite.kiteui.views.*
 import com.lightningkite.kiteui.views.ViewWriter
 import com.lightningkite.kiteui.views.direct.*
 import com.lightningkite.mppexampleapp.Resources
-import com.lightningkite.reactive.context.*
 import com.lightningkite.reactive.core.*
-import com.lightningkite.reactive.extensions.*
-import com.lightningkite.reactive.lensing.*
-import com.lightningkite.readable.*
 
 @Routable("image-test")
 object ImageTestPage : Page {
@@ -20,17 +16,27 @@ object ImageTestPage : Page {
         get() = super.title
 
     override fun ViewWriter.render(): ViewModifiable = run {
-        frame {
-            centered - sizeConstraints(width = 40.rem) - col {
-                val value = Signal(false)
-                card - toggleButton {
-                    checked bind value
-                    text("Show")
+            scrolling - sizeConstraints(width = 40.rem) - col {
+
+                text("scaleType = ${ImageScaleType.Crop}")
+
+                 centered -  sizeConstraints(
+                    width = 6.rem,
+                    height = 6.rem
+                ) - image {
+                    source = Resources.imagesSnowyBackground
+                    scaleType = ImageScaleType.Crop
                 }
-                image {
-                    ::source { if(value()) Resources.imagesSnowyBackground else null }
+
+                text("scaleType = ${ImageScaleType.Stretch}")
+                centered -  sizeConstraints(
+                    width = 6.rem,
+                    height = 6.rem
+                ) - image {
+                    source = Resources.imagesSnowyBackground
+                    scaleType = ImageScaleType.Stretch
                 }
+
             }
         }
-    }
 }

--- a/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/RootPage.kt
+++ b/example-app/src/commonMain/kotlin/com/lightningkite/mppexampleapp/internal/RootPage.kt
@@ -95,6 +95,7 @@ object RootPage : Page {
                 linkPage { ExternalServicesPage }
                 linkPage { FullScreenPage() }
                 linkPage { RecyclerViewTestPage }
+                linkPage { ImageTestPage }
                 linkPage { PerformanceTestPage }
                 run {
                     val screen = { ArgumentsExamplePage("test-id").also { it.toAdd.value = "Preset" } }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/RView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/RView.ios.kt
@@ -181,6 +181,11 @@ actual abstract class RView actual constructor(context: RContext) : RViewHelper(
     var effectBackground: BlurBackgroundView? = null
 
     actual override fun applyTheme(theme: ThemeAndBack) {
+        native.clipsToBounds = theme.drawBackground
+        applyBackgroundChanges(theme)
+    }
+
+    protected fun applyBackgroundChanges(theme: ThemeAndBack) {
         if (theme.drawBackground && theme.theme.elevation.value != 0.0) native.layer.apply {
             val v = theme.theme.elevation.value
             shadowColor = UIColor.grayColor.CGColor
@@ -215,12 +220,8 @@ actual abstract class RView actual constructor(context: RContext) : RViewHelper(
             else -> theme.theme.padding
         }
 
+
         val fullyApply = theme.drawBackground
-
-        if (this !is RawImageViewLike) {
-            native.clipsToBounds = fullyApply // Images handle clipsToBounds internally
-        }
-
         animateIfAllowed {
 //            native.clearOldLayers()
 //            if(fullyApply) applyThemeBackground(theme, native, parent?.mySpacing ?: theme.gap)

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/RView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/RView.ios.kt
@@ -6,6 +6,7 @@ import com.lightningkite.kiteui.models.*
 import com.lightningkite.kiteui.models.px
 import com.lightningkite.kiteui.objc.*
 import com.lightningkite.kiteui.reactive.AppState
+import com.lightningkite.kiteui.views.direct.RawImageViewLike
 import com.lightningkite.kiteui.views.direct.WrapperView
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
@@ -215,7 +216,11 @@ actual abstract class RView actual constructor(context: RContext) : RViewHelper(
         }
 
         val fullyApply = theme.drawBackground
-        native.clipsToBounds = fullyApply
+
+        if (this !is RawImageViewLike) {
+            native.clipsToBounds = fullyApply // Images handle clipsToBounds internally
+        }
+
         animateIfAllowed {
 //            native.clearOldLayers()
 //            if(fullyApply) applyThemeBackground(theme, native, parent?.mySpacing ?: theme.gap)

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.ios.kt
@@ -56,6 +56,11 @@ actual abstract class RawImageViewLike constructor(
 
     protected suspend fun load(value: ImageSource?, size: Size?): UIImage? = value.load(size)
 
+    override fun applyTheme(theme: ThemeAndBack) {
+        native.clipsToBounds = true
+        super.applyBackgroundChanges(theme)
+    }
+
     override val disableBackground = true
 }
 
@@ -128,7 +133,6 @@ actual class RawImageView actual constructor(
     override val native = UIImageViewFixedSizing()
 
     init {
-        native.clipsToBounds = true
         native.contentMode = when (scaleType) {
             ImageScaleType.Fit -> UIViewContentMode.UIViewContentModeScaleAspectFit
             ImageScaleType.Crop -> UIViewContentMode.UIViewContentModeScaleAspectFill
@@ -164,7 +168,6 @@ actual class SizelessRawImageView actual constructor(
     override val native = UIImageViewFixedSizing().also { it.ignoreNaturalSize = true }
 
     init {
-        native.clipsToBounds = true
         native.contentMode = when (scaleType) {
             ImageScaleType.Fit -> UIViewContentMode.UIViewContentModeScaleAspectFit
             ImageScaleType.Crop -> UIViewContentMode.UIViewContentModeScaleAspectFill


### PR DESCRIPTION
`RawImageView.ios.kt` sets `clipsToBounds` to true for all images, but `RView.ios.kt` sets it based on the view draws a background or not, which overrides clipToBounds and makes the image overflow its container.  I don't think it makes sense to have Images with clipToBounds as false, so I think it's safe to avoid setting it for images in RView.