### PR TITLE
Fix popover stretch issue at certain widths. Fix ios and android popover for menubuttons using the new semantic

### DIFF
--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/MenuButton.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/MenuButton.android.kt
@@ -37,7 +37,7 @@ actual class MenuButton actual constructor(context: RContext): RView(context) {
                     onClick {
                         closePopovers()
                     }
-                    atTopStart - dialog - frame {
+                    atTopStart - PopoverSemantic.onNext - frame {
                         this@dismissBackground.native.apply {
                             clipChildren = false
                             clipToPadding = false

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/MenuButton.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/MenuButton.ios.kt
@@ -42,7 +42,7 @@ actual class MenuButton actual constructor(context: RContext): RView(context) {
                     onClick {
                         closePopovers()
                     }
-                    dialog - frame {
+                    PopoverSemantic.onNext - frame {
                         createMenu()
                     }
                 }

--- a/library/src/jsMain/kotlin/com/lightningkite/kiteui/views/direct/FloatingInfoHolder.js.kt
+++ b/library/src/jsMain/kotlin/com/lightningkite/kiteui/views/direct/FloatingInfoHolder.js.kt
@@ -145,8 +145,10 @@ actual class FloatingInfoHolder actual constructor(val source: RView) {
                         }
                             .firstOrNull {
                                 val proposed = it.bounds()
-                                proposed.left >= screen.left && proposed.right <= screen.right &&
-                                    proposed.top >= screen.top && proposed.bottom <= screen.bottom
+                                val epsilon =
+                                    0.01 // Fix precision mismatch i.e. screen.right is 1231 but proposed is 1231.0000457763672
+                                (proposed.left >= screen.left - epsilon) && (proposed.right <= screen.right + epsilon) &&
+                                        (proposed.top >= screen.top - epsilon) && (proposed.bottom <= screen.bottom + epsilon)
                             }
 
                         if(currentDirection == null) {


### PR DESCRIPTION
Fix issue where at certain dimensions the popover will align with stretch instead of start or end because of a precision issue. Ios and android popover was not using the updated PopoverSemantic