### PR TITLE
Bug fixes: WebSocket, connectivity, back button, AppNav keyboard, fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ library.podspec
 local
 .kbuild
 /.claude/settings.local.json
+worktrees
+sstest*.png
+screenshot-*.png
+.fork/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,15 +45,31 @@ This is a multi-module Gradle project:
 ```
 
 ### Testing
-```bash
-# Run all tests
-./gradlew allTests
 
-# Run tests for specific platform
-./gradlew :library:jvmTest
-./gradlew :library:jsTest
-./gradlew :library:iosX64Test
+See **[docs/RUNNING_TESTS.md](docs/RUNNING_TESTS.md)** for the full guide including prerequisites, gotchas, and how to write tests.
+
+```bash
+# Fastest — no external tools needed
+./gradlew :example-app:jvmSsrTest
+
+# Android (Robolectric, no device needed)
+./gradlew :example-app:testDebugUnitTest
+
+# iOS (requires running Simulator)
+./gradlew :example-app:iosSimulatorArm64Test
+
+# JS/Web (requires Chrome)
+./gradlew :example-app:jsBrowserTest
+
+# All platforms at once
+./gradlew :example-app:allTests
+
+# Filter to a specific test class (JVM SSR and Android only)
+./gradlew :example-app:jvmSsrTest --tests "*.MyTestClass"
+./gradlew :example-app:testDebugUnitTest --tests "*.MyTestClass"
 ```
+
+Substitute `:library:` for `:example-app:` to run library tests instead.
 
 ### Running Example App
 ```bash

--- a/library-swing/src/jvmMain/kotlin/com/lightningkite/kiteui/fetch.jvm.kt
+++ b/library-swing/src/jvmMain/kotlin/com/lightningkite/kiteui/fetch.jvm.kt
@@ -186,7 +186,6 @@ class WebSocketWrapper(val url: String) : WebSocket {
         AppScope.launch(Dispatchers.IO) {
             try {
                 client.webSocket(url) {
-                    // by Claude — Bug 1: flag to ensure onClose fires exactly once
                     var onCloseFired = false
                     withContext(Dispatchers.Main) {
                         onOpen.forEach { it() }
@@ -239,7 +238,7 @@ class WebSocketWrapper(val url: String) : WebSocket {
                                 else -> {}
                             }
                         } catch (e: ClosedReceiveChannelException) {
-                            break // by Claude — channel closed, exit loop
+                            break
                         }
                     }
                     withContext(Dispatchers.Main) {
@@ -292,9 +291,7 @@ class WebSocketWrapper(val url: String) : WebSocket {
 
 actual class FileReference(val file: File)
 
-// by Claude - create FileReference from raw bytes for testing/mocking
 actual fun createFileReferenceFromBytes(bytes: ByteArray, mimeType: String, fileName: String): FileReference {
-    // by Claude - use a subdirectory so the original fileName is preserved for fileName()
     val dir = File(System.getProperty("java.io.tmpdir"), "kiteui-mock-${System.nanoTime()}")
     dir.mkdirs()
     dir.deleteOnExit()

--- a/library-swing/src/jvmMain/kotlin/com/lightningkite/kiteui/fetch.jvm.kt
+++ b/library-swing/src/jvmMain/kotlin/com/lightningkite/kiteui/fetch.jvm.kt
@@ -186,6 +186,8 @@ class WebSocketWrapper(val url: String) : WebSocket {
         AppScope.launch(Dispatchers.IO) {
             try {
                 client.webSocket(url) {
+                    // by Claude — Bug 1: flag to ensure onClose fires exactly once
+                    var onCloseFired = false
                     withContext(Dispatchers.Main) {
                         onOpen.forEach { it() }
                     }
@@ -202,7 +204,10 @@ class WebSocketWrapper(val url: String) : WebSocket {
                             this@WebSocketWrapper.closeReason.receive().let { reason ->
                                 close(reason)
                                 withContext(Dispatchers.Main) {
-                                    onClose.forEach { it(reason.code) }
+                                    if (!onCloseFired) {
+                                        onCloseFired = true
+                                        onClose.forEach { it(reason.code) }
+                                    }
                                 }
                             }
                         } catch (e: ClosedReceiveChannelException) {
@@ -234,15 +239,20 @@ class WebSocketWrapper(val url: String) : WebSocket {
                                 else -> {}
                             }
                         } catch (e: ClosedReceiveChannelException) {
+                            break // by Claude — channel closed, exit loop
                         }
                     }
                     withContext(Dispatchers.Main) {
-                        onClose.forEach { it(reason?.code ?: 0) }
+                        if (!onCloseFired) {
+                            onCloseFired = true
+                            onClose.forEach { it(reason?.code ?: 0) }
+                        }
                     }
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
+                fetchLog.log("WebSocket connection failed: ${e::class.simpleName}: ${e.message}")
                 withContext(Dispatchers.Main) {
                     onClose.forEach { it(0) }
                 }
@@ -282,6 +292,17 @@ class WebSocketWrapper(val url: String) : WebSocket {
 
 actual class FileReference(val file: File)
 
+// by Claude - create FileReference from raw bytes for testing/mocking
+actual fun createFileReferenceFromBytes(bytes: ByteArray, mimeType: String, fileName: String): FileReference {
+    // by Claude - use a subdirectory so the original fileName is preserved for fileName()
+    val dir = File(System.getProperty("java.io.tmpdir"), "kiteui-mock-${System.nanoTime()}")
+    dir.mkdirs()
+    dir.deleteOnExit()
+    val tempFile = File(dir, fileName)
+    tempFile.deleteOnExit()
+    tempFile.writeBytes(bytes)
+    return FileReference(tempFile)
+}
 
 actual fun Blob.mimeType() = type
 actual fun FileReference.mimeType() = Files.probeContentType(file.toPath()) ?: "application/octet-stream"

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/KiteUiActivity.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/KiteUiActivity.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.ViewTreeObserver
 import android.view.WindowManager
 import com.lightningkite.kiteui.gamepad.Gamepads
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
@@ -101,6 +102,17 @@ abstract class KiteUiActivity : AppCompatActivity() {
         }
         this.savedInstanceState = savedInstanceState
         onNewIntent(intent)
+
+        // by Claude - Use modern back handling API instead of deprecated onBackPressed()
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (!mainNavigator.goBack()) {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                    isEnabled = true
+                }
+            }
+        })
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -230,12 +242,6 @@ abstract class KiteUiActivity : AppCompatActivity() {
         animator = null
         super.onPause()
         AppState._inForeground.value = false
-    }
-
-    override fun onBackPressed() {
-        if(!mainNavigator.goBack()) {
-            super.onBackPressed()
-        }
     }
 
     override fun onGenericMotionEvent(event: MotionEvent): Boolean {

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/KiteUiActivity.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/KiteUiActivity.kt
@@ -103,7 +103,7 @@ abstract class KiteUiActivity : AppCompatActivity() {
         this.savedInstanceState = savedInstanceState
         onNewIntent(intent)
 
-        // by Claude - Use modern back handling API instead of deprecated onBackPressed()
+        // Use modern back handling API instead of deprecated onBackPressed()
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 if (!mainNavigator.goBack()) {

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/fetch.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/fetch.android.kt
@@ -220,7 +220,7 @@ class WebSocketWrapper(val url: String) : WebSocket {
         @Suppress("OPT_IN_USAGE")
         AppScope.launch(Dispatchers.IO) {
             try {
-                // by Claude - Retry on UnknownHostException, same Android DNS bug as HTTP fetch
+                // Retry on UnknownHostException, same Android DNS bug as HTTP fetch
                 // https://github.com/square/okhttp/issues/8200
                 val maxRetries = 5
                 var attempt = 0
@@ -229,7 +229,6 @@ class WebSocketWrapper(val url: String) : WebSocket {
                         attempt++
                         client.webSocket(url) {
                             attempt = 0 // Reset on successful connection
-                            // by Claude — Bug 1: flag to ensure onClose fires exactly once
                             var onCloseFired = false
                             withContext(Dispatchers.Main) {
                                 onOpen.forEach { it() }
@@ -384,10 +383,6 @@ actual fun FileReference.fileName(): String {
 }
 
 actual class Blob(val data: ByteArray, val type: String)
-
-// by Claude — Bug 8: removed unused webSocketClient (CIO engine); WebSocket connections use
-// `client` (OkHttp via AndroidAppContext.ktorClient). The JVM variants properly alias
-// client = webSocketClient, but Android doesn't use this at all.
 
 actual fun Blob.bytes(): Long = data.size.toLong()
 actual fun FileReference.bytes(): Long {

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/fetch.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/fetch.android.kt
@@ -10,7 +10,6 @@ import com.lightningkite.kiteui.views.AndroidAppContext
 import com.lightningkite.reactive.core.*
 import io.ktor.client.*
 import io.ktor.client.call.*
-import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
@@ -21,7 +20,6 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toByteReadChannel
 import io.ktor.websocket.*
 import java.net.UnknownHostException
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -62,6 +60,7 @@ actual suspend fun fetch(
     while (true) {
         try {
             attempt++
+            fetchLog.log("-> $method $url")
             val response = client.request(url) {
                 this.method = when (method) {
                     HttpMethod.GET -> io.ktor.http.HttpMethod.Get
@@ -112,11 +111,12 @@ actual suspend fun fetch(
                     }
                 }
             }
+            fetchLog.log("<- $method $url ${response.status}")
             return RequestResponse(response)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            fetchLog.log("Attempt $attempt: <X $method $url ${e::class} ${e.message}")
+            fetchLog.log("<X $method $url ${e::class.simpleName}: ${e.message}")
             if (attempt >= maxRetries || e !is UnknownHostException) {
                 throw ConnectionException("Network request failed", e)
             }
@@ -220,64 +220,93 @@ class WebSocketWrapper(val url: String) : WebSocket {
         @Suppress("OPT_IN_USAGE")
         AppScope.launch(Dispatchers.IO) {
             try {
-                client.webSocket(url) {
-                    withContext(Dispatchers.Main) {
-                        onOpen.forEach { it() }
-                    }
-                    launch {
-                        try {
+                // by Claude - Retry on UnknownHostException, same Android DNS bug as HTTP fetch
+                // https://github.com/square/okhttp/issues/8200
+                val maxRetries = 5
+                var attempt = 0
+                while (true) {
+                    try {
+                        attempt++
+                        client.webSocket(url) {
+                            attempt = 0 // Reset on successful connection
+                            // by Claude — Bug 1: flag to ensure onClose fires exactly once
+                            var onCloseFired = false
+                            withContext(Dispatchers.Main) {
+                                onOpen.forEach { it() }
+                            }
+                            launch {
+                                try {
+                                    while (stayOn) {
+                                        send(sending.receive())
+                                    }
+                                } catch (e: ClosedReceiveChannelException) {
+                                }
+                            }
+                            launch {
+                                try {
+                                    this@WebSocketWrapper.closeReason.receive().let { reason ->
+                                        close(reason)
+                                        withContext(Dispatchers.Main) {
+                                            if (!onCloseFired) {
+                                                onCloseFired = true
+                                                onClose.forEach { it(reason.code) }
+                                            }
+                                        }
+                                    }
+                                } catch (e: ClosedReceiveChannelException) {
+                                }
+                            }
+                            var reason: CloseReason? = null
                             while (stayOn) {
-                                send(sending.receive())
-                            }
-                        } catch (e: ClosedReceiveChannelException) {
-                        }
-                    }
-                    launch {
-                        try {
-                            this@WebSocketWrapper.closeReason.receive().let { reason ->
-                                close(reason)
-                                withContext(Dispatchers.Main) {
-                                    onClose.forEach { it(reason.code) }
-                                }
-                            }
-                        } catch (e: ClosedReceiveChannelException) {
-                        }
-                    }
-                    var reason: CloseReason? = null
-                    while (stayOn) {
-                        try {
-                            when (val x = incoming.receive()) {
-                                is Frame.Binary -> {
-                                    val data = Blob(x.data, "application/octet-stream")
-                                    withContext(Dispatchers.Main) {
-                                        onBinaryMessage.forEach { it(data) }
+                                try {
+                                    when (val x = incoming.receive()) {
+                                        is Frame.Binary -> {
+                                            val data = Blob(x.data, "application/octet-stream")
+                                            withContext(Dispatchers.Main) {
+                                                onBinaryMessage.forEach { it(data) }
+                                            }
+                                        }
+
+                                        is Frame.Text -> {
+                                            val text = x.readText()
+                                            withContext(Dispatchers.Main) {
+                                                onMessage.forEach { it(text) }
+                                            }
+                                        }
+
+                                        is Frame.Close -> {
+                                            reason = x.readReason()
+                                            break
+                                        }
+
+                                        else -> {}
                                     }
+                                } catch (e: ClosedReceiveChannelException) {
+                                    break // by Claude — channel closed, exit loop
                                 }
-
-                                is Frame.Text -> {
-                                    val text = x.readText()
-                                    withContext(Dispatchers.Main) {
-                                        onMessage.forEach { it(text) }
-                                    }
-                                }
-
-                                is Frame.Close -> {
-                                    reason = x.readReason()
-                                    break
-                                }
-
-                                else -> {}
                             }
-                        } catch (e: ClosedReceiveChannelException) {
+                            withContext(Dispatchers.Main) {
+                                if (!onCloseFired) {
+                                    onCloseFired = true
+                                    onClose.forEach { it(reason?.code ?: 0) }
+                                }
+                            }
                         }
-                    }
-                    withContext(Dispatchers.Main) {
-                        onClose.forEach { it(reason?.code ?: 0) }
+                        break // Normal exit from webSocket block, don't retry
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        if (attempt < maxRetries && (e.cause is UnknownHostException || e is UnknownHostException)) {
+                            delay(2.seconds)
+                            continue
+                        }
+                        throw e
                     }
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch(e: Exception) {
+                fetchLog.log("WebSocket connection failed: ${e::class.simpleName}: ${e.message}")
                 withContext(Dispatchers.Main) {
                     onClose.forEach { it(0) }
                 }
@@ -317,6 +346,16 @@ class WebSocketWrapper(val url: String) : WebSocket {
 
 actual class FileReference(val uri: Uri)
 
+// by Claude - create FileReference from raw bytes for testing/mocking
+actual fun createFileReferenceFromBytes(bytes: ByteArray, mimeType: String, fileName: String): FileReference {
+    // by Claude - use a subdirectory so the original fileName is preserved for fileName()
+    val cacheDir = AndroidAppContext.applicationCtx.cacheDir
+    val dir = java.io.File(cacheDir, "kiteui-mock-${System.nanoTime()}")
+    dir.mkdirs()
+    val tempFile = java.io.File(dir, fileName)
+    tempFile.writeBytes(bytes)
+    return FileReference(Uri.fromFile(tempFile))
+}
 
 actual fun Blob.mimeType() = type
 actual fun FileReference.mimeType() = when (uri.scheme) {
@@ -346,13 +385,9 @@ actual fun FileReference.fileName(): String {
 
 actual class Blob(val data: ByteArray, val type: String)
 
-val webSocketClient: HttpClient by lazy {
-    HttpClient(CIO) {
-        install(WebSockets) {
-            pingInterval = 20_000.milliseconds
-        }
-    }
-}
+// by Claude — Bug 8: removed unused webSocketClient (CIO engine); WebSocket connections use
+// `client` (OkHttp via AndroidAppContext.ktorClient). The JVM variants properly alias
+// client = webSocketClient, but Android doesn't use this at all.
 
 actual fun Blob.bytes(): Long = data.size.toLong()
 actual fun FileReference.bytes(): Long {

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/fetch-connectivity.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/fetch-connectivity.kt
@@ -33,7 +33,6 @@ class WaitGate(permit: Boolean = false) {
         permit = false
     }
     val continuations = ArrayList<Continuation<Unit>>()
-    // by Claude — Bug 5: clean up cancelled continuations to prevent memory leaks
     suspend fun await(): Unit {
         if (permit) return
         else return suspendCancellableCoroutine {
@@ -102,7 +101,6 @@ object Connectivity {
     val lastConnectivityIssueCode: Signal<Short> = Signal(0)
 }
 
-// by Claude — Bug 6: check stop connectivity codes on ALL responses, not just retries
 suspend fun connectivityFetch(
     url: String,
     method: HttpMethod = HttpMethod.GET,

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/fetch-connectivity.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/fetch-connectivity.kt
@@ -33,10 +33,12 @@ class WaitGate(permit: Boolean = false) {
         permit = false
     }
     val continuations = ArrayList<Continuation<Unit>>()
+    // by Claude — Bug 5: clean up cancelled continuations to prevent memory leaks
     suspend fun await(): Unit {
         if (permit) return
         else return suspendCancellableCoroutine {
             continuations.add(it)
+            it.invokeOnCancellation { _ -> continuations.remove(it) }
         }
     }
     fun abandon() {
@@ -100,6 +102,7 @@ object Connectivity {
     val lastConnectivityIssueCode: Signal<Short> = Signal(0)
 }
 
+// by Claude — Bug 6: check stop connectivity codes on ALL responses, not just retries
 suspend fun connectivityFetch(
     url: String,
     method: HttpMethod = HttpMethod.GET,
@@ -108,23 +111,23 @@ suspend fun connectivityFetch(
 ): RequestResponse {
     return if(coroutineContext[ConnectivityIssueSuppress.Key] == null) {
         Connectivity.fetchGate.run("$method $url") {
-            try {
+            val response = try {
                 fetch(url = url, method = method, headers = headers(), body = body)
             } catch(e: ConnectionException) {
                 // Perform a single retry immediately
                 Log.warn("Forced retry on $method $url")
-                val r = try {
+                try {
                     fetch(url = url, method = method, headers = headers(), body = body)
                 } catch(e: ConnectionException) {
                     Connectivity.lastConnectivityIssueCode.value = 0
                     throw e
                 }
-                if (r.status in Connectivity.stopConnectivityCodes) {
-                    Connectivity.lastConnectivityIssueCode.value = r.status
-                    throw ConnectionException("Status code ${r.status}")
-                }
-                r
             }
+            if (response.status in Connectivity.stopConnectivityCodes) {
+                Connectivity.lastConnectivityIssueCode.value = response.status
+                throw ConnectionException("Status code ${response.status}")
+            }
+            response
         }
     } else {
         fetch(url = url, method = method, headers = headers(), body = body)

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/fetch.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/fetch.kt
@@ -56,7 +56,6 @@ expect class RequestResponse {
 expect class Blob
 expect class FileReference
 
-// by Claude - create a FileReference from raw bytes, useful for mocking file picks in tests
 expect fun createFileReferenceFromBytes(bytes: ByteArray, mimeType: String, fileName: String): FileReference
 
 expect fun String.toBlob(contentType: String = "text/plain"): Blob

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/fetch.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/fetch.kt
@@ -56,6 +56,9 @@ expect class RequestResponse {
 expect class Blob
 expect class FileReference
 
+// by Claude - create a FileReference from raw bytes, useful for mocking file picks in tests
+expect fun createFileReferenceFromBytes(bytes: ByteArray, mimeType: String, fileName: String): FileReference
+
 expect fun String.toBlob(contentType: String = "text/plain"): Blob
 expect fun Blob.mimeType(): String
 expect fun Blob.bytes(): Long

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/reactive/Action.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/reactive/Action.kt
@@ -41,7 +41,7 @@ fun Action(
 }
 
 class FrequencyCapAction(val wraps: Action, val frequencyCap: Duration = 500.milliseconds) : Action by wraps {
-    // by Claude - initialize in the past so the first invocation is never suppressed
+    // initialize in the past so the first invocation is never suppressed
     private var lastInvoked = TimeSource.Monotonic.markNow() - frequencyCap - 1.milliseconds
 
     override fun startAction(scope: CoroutineScope) {

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/reactive/Action.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/reactive/Action.kt
@@ -41,7 +41,8 @@ fun Action(
 }
 
 class FrequencyCapAction(val wraps: Action, val frequencyCap: Duration = 500.milliseconds) : Action by wraps {
-    private var lastInvoked = TimeSource.Monotonic.markNow()
+    // by Claude - initialize in the past so the first invocation is never suppressed
+    private var lastInvoked = TimeSource.Monotonic.markNow() - frequencyCap - 1.milliseconds
 
     override fun startAction(scope: CoroutineScope) {
         if (lastInvoked.elapsedNow() > frequencyCap) {

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/l2/AppNav.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/l2/AppNav.kt
@@ -182,7 +182,7 @@ fun ViewWriter.appNavBottomTabs(setup: AppNav.() -> Unit): Unit {
         }
         val tabsHandleBottom = remember { appNav.existsProperty() && !AppState.softInputOpen() }
         beforeNextElementSetup {
-            // by Claude - Apply bottom safe insets when keyboard is open, since the tab bar
+            // Apply bottom safe insets when keyboard is open, since the tab bar
             // (which normally handles the bottom inset) is hidden during keyboard input.
             applySafeInsets { edges ->
                 Edges(

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/l2/AppNav.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/l2/AppNav.kt
@@ -180,15 +180,25 @@ fun ViewWriter.appNavBottomTabs(setup: AppNav.() -> Unit): Unit {
                 ::shown { appNav.existsProperty() }
             }
         }
+        val tabsHandleBottom = remember { appNav.existsProperty() && !AppState.softInputOpen() }
         beforeNextElementSetup {
-            applySafeInsets(top = false, bottom = false)
+            // by Claude - Apply bottom safe insets when keyboard is open, since the tab bar
+            // (which normally handles the bottom inset) is hidden during keyboard input.
+            applySafeInsets { edges ->
+                Edges(
+                    left = edges.left,
+                    top = if(appNav.existsProperty()) 0.px else edges.top,
+                    right = edges.right,
+                    bottom = if (!tabsHandleBottom()) edges.bottom else 0.px,
+                )
+            }
         }.expanding.navigatorView(pageNavigator)
         //Nav 3 - top and bottom (bottom/tabs)
         nav.navGroupTabs(appNav.navItemsProperty) {
             applySafeInsets(top = false)
             debugName = "navGroupTabs"
             showOnPrint = false
-            ::shown { appNav.existsProperty() && !AppState.softInputOpen() }
+            ::shown { tabsHandleBottom() }
         }
     }
 }

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/wsretry.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/wsretry.kt
@@ -19,16 +19,14 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 
+// by Claude — Bug 9: removed artificial 100ms delay; resume immediately on connect
 suspend fun WebSocket.waitUntilConnect(delay: suspend (Long) -> Unit = { kotlinx.coroutines.delay(it) }) {
     suspendCancellableCoroutine<Unit> {
         var alreadyResumed = false
         onOpen {
-            AppScope.launch {
-                delay(100L)
-                if (!alreadyResumed) {
-                    alreadyResumed = true
-                    it.resume(Unit)
-                }
+            if (!alreadyResumed) {
+                alreadyResumed = true
+                it.resume(Unit)
             }
         }
         onClose { code ->
@@ -59,8 +57,7 @@ fun retryWebsocket(
     log: Log? = null,
 ): RetryWebsocket {
     log?.log("Creating")
-    val baseDelay = 1000L
-    var currentDelay = baseDelay
+    // by Claude — Bug 7: removed dead `currentDelay` (was never read; ConnectivityGate handles backoff)
     var lastConnect = 0.0
     val connected = Signal(false).also {
         it.addListener {
@@ -76,28 +73,37 @@ fun retryWebsocket(
     var instanceCount: Int = 0
     var currentWebSocketId = -1
     suspend fun reset() {
+        // by Claude — Bug 2: update ID first so old socket's handlers are considered stale
         val id = instanceCount++
         currentWebSocketId = id
+        // by Claude — Bug 2: close old socket to prevent leaked connections and stale events
+        currentWebSocket?.close(1000, "Reconnecting")
         currentWebSocket = underlyingSocket().also { socket ->
             var pings: Job? = null
+            // by Claude — Bug 2: all handlers check staleness to ignore events from old sockets
             socket.onOpen {
+                if (id != currentWebSocketId) return@onOpen
                 log?.log("$id onOpen")
                 onOpenList.toList().forEach { l -> l() }
             }
             socket.onMessage {
+                if (id != currentWebSocketId) return@onMessage
                 log?.log("$id onMessage $it")
                 lastPong = clockMillis()
                 if (it.isNotBlank()) onMessageList.toList().forEach { l -> l(it) }
             }
             socket.onBinaryMessage {
+                if (id != currentWebSocketId) return@onBinaryMessage
                 log?.log("$id onBinaryMessage $it")
                 onBinaryMessageList.toList().forEach { l -> l(it) }
             }
             socket.onClose {
+                if (id != currentWebSocketId) return@onClose
                 log?.log("$id onClose $it")
                 onCloseList.toList().forEach { l -> l(it) }
             }
             socket.onOpen {
+                if (id != currentWebSocketId) return@onOpen
                 lastConnect = clockMillis()
                 lastPong = lastConnect
                 connected.value = true
@@ -105,12 +111,17 @@ fun retryWebsocket(
                 pings = AppScope.launch {
                     while (true) {
                         delay(pingTime)
+                        if (id != currentWebSocketId) return@launch
                         val now = clockMillis()
                         when {
-                            lastPong < now - (pingTime * 3) -> socket.close(
-                                3000,
-                                "Server did not respond to three consecutive pings."
-                            )
+                            // by Claude — Bug 10: exit ping loop after sending close
+                            lastPong < now - (pingTime * 3) -> {
+                                socket.close(
+                                    3000,
+                                    "Server did not respond to three consecutive pings."
+                                )
+                                return@launch
+                            }
 
                             lastPong < now - pingTime.times(0.8) -> socket.send(" ")
                         }
@@ -118,9 +129,8 @@ fun retryWebsocket(
                 }
             }
             socket.onClose {
+                if (id != currentWebSocketId) return@onClose
                 pings?.cancel()
-                currentDelay *= 2
-                if (connected.value && clockMillis() - lastConnect > (pingTime * 2)) currentDelay = baseDelay
                 connected.value = false
             }
         }

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/wsretry.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/wsretry.kt
@@ -57,7 +57,6 @@ fun retryWebsocket(
     log: Log? = null,
 ): RetryWebsocket {
     log?.log("Creating")
-    // by Claude — Bug 7: removed dead `currentDelay` (was never read; ConnectivityGate handles backoff)
     var lastConnect = 0.0
     val connected = Signal(false).also {
         it.addListener {
@@ -73,14 +72,11 @@ fun retryWebsocket(
     var instanceCount: Int = 0
     var currentWebSocketId = -1
     suspend fun reset() {
-        // by Claude — Bug 2: update ID first so old socket's handlers are considered stale
         val id = instanceCount++
         currentWebSocketId = id
-        // by Claude — Bug 2: close old socket to prevent leaked connections and stale events
         currentWebSocket?.close(1000, "Reconnecting")
         currentWebSocket = underlyingSocket().also { socket ->
             var pings: Job? = null
-            // by Claude — Bug 2: all handlers check staleness to ignore events from old sockets
             socket.onOpen {
                 if (id != currentWebSocketId) return@onOpen
                 log?.log("$id onOpen")

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/fetch.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/fetch.ios.kt
@@ -30,6 +30,9 @@ import platform.UniformTypeIdentifiers.*
 import platform.posix.memcpy
 import kotlin.coroutines.resumeWithException
 
+// by Claude
+private val fetchLog = LogRoot.tag("fetch")
+
 val client = HttpClient {
     install(WebSockets)
     install(UserAgent) {
@@ -60,8 +63,10 @@ actual suspend fun fetch(
     onUploadProgress: ((bytesComplete: Long, bytesExpectedOrNegativeOne: Long) -> Unit)?,
     onDownloadProgress: ((bytesComplete: Long, bytesExpectedOrNegativeOne: Long) -> Unit)?,
 ): RequestResponse {
+    // by Claude — add request/response logging matching JVM SSR/Android behavior
     return run {
         try {
+            fetchLog.log("-> $method $url")
             val response = run {
                 client.request(url) {
                     this.method = when (method) {
@@ -138,10 +143,12 @@ actual suspend fun fetch(
                 }
             }
 
+            fetchLog.log("<- $method $url ${response.status}")
             RequestResponse(response)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            fetchLog.log("<X $method $url ${e::class.simpleName}: ${e.message}")
             throw ConnectionException("Network request failed", e)
         }
     }
@@ -176,34 +183,25 @@ actual class HttpHeaders(val map: MutableMap<String, List<String>>) {
 actual class RequestResponse(val wraps: HttpResponse) {
     actual val status: Short get() = wraps.status.value.toShort()
     actual val ok: Boolean get() = wraps.status.isSuccess()
+    // by Claude — Bug 4: wrap exceptions in ConnectionException, matching Android/JVM behavior
     actual suspend fun text(): String {
         try {
-            val result = run {
-                run {
-                    wraps.bodyAsText()
-                }
-            }
-            return result
+            return wraps.bodyAsText()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            throw e
+            throw ConnectionException("Reading body failed", e)
         }
     }
 
     actual suspend fun blob(): Blob {
         try {
-            val result = run {
-                run {
-                    wraps.body<ByteArray>()
-                        .let { Blob(it.toNSData(), wraps.contentType()?.toString() ?: "application/octet-stream") }
-                }
-            }
-            return result
+            return wraps.body<ByteArray>()
+                .let { Blob(it.toNSData(), wraps.contentType()?.toString() ?: "application/octet-stream") }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            throw e
+            throw ConnectionException("Reading body failed", e)
         }
     }
 
@@ -250,6 +248,8 @@ class WebSocketWrapper(val url: String) : WebSocket {
         AppScope.launch(Dispatchers.IO) {
             try {
                 client.webSocket(url) {
+                    // by Claude — Bug 1: flag to ensure onClose fires exactly once
+                    var onCloseFired = false
                     withContext(Dispatchers.Main) {
                         onOpen.forEach { it() }
                     }
@@ -266,7 +266,10 @@ class WebSocketWrapper(val url: String) : WebSocket {
                             this@WebSocketWrapper.closeReason.receive().let { reason ->
                                 close(reason)
                                 withContext(Dispatchers.Main) {
-                                    onClose.forEach { it(reason.code) }
+                                    if (!onCloseFired) {
+                                        onCloseFired = true
+                                        onClose.forEach { it(reason.code) }
+                                    }
                                 }
                             }
                         } catch (e: ClosedReceiveChannelException) {
@@ -298,15 +301,20 @@ class WebSocketWrapper(val url: String) : WebSocket {
                                 else -> {}
                             }
                         } catch (e: ClosedReceiveChannelException) {
+                            break // by Claude — channel closed, exit loop
                         }
                     }
                     withContext(Dispatchers.Main) {
-                        onClose.forEach { it(reason?.code ?: 0) }
+                        if (!onCloseFired) {
+                            onCloseFired = true
+                            onClose.forEach { it(reason?.code ?: 0) }
+                        }
                     }
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch(e: Exception) {
+                fetchLog.log("WebSocket connection failed: ${e::class.simpleName}: ${e.message}")
                 withContext(Dispatchers.Main) {
                     onClose.forEach { it(0) }
                 }
@@ -346,6 +354,18 @@ class WebSocketWrapper(val url: String) : WebSocket {
 
 actual class Blob(val data: NSData, val type: String = "application/octet-stream")
 actual class FileReference(val provider: NSItemProvider, val suggestedType: UTType? = null)
+
+// by Claude - create FileReference from raw bytes for testing/mocking
+@OptIn(ExperimentalForeignApi::class)
+actual fun createFileReferenceFromBytes(bytes: ByteArray, mimeType: String, fileName: String): FileReference {
+    val nsData = bytes.usePinned { pinned ->
+        NSData.dataWithBytes(pinned.addressOf(0), bytes.size.toULong())
+    }
+    val utType = UTType.typeWithMIMEType(mimeType) ?: UTTypeData
+    val provider = NSItemProvider(item = nsData, typeIdentifier = utType.identifier)
+    provider.suggestedName = fileName
+    return FileReference(provider, utType)
+}
 
 
 actual fun Blob.mimeType(): String = type

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/fetch.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/fetch.ios.kt
@@ -63,7 +63,6 @@ actual suspend fun fetch(
     onUploadProgress: ((bytesComplete: Long, bytesExpectedOrNegativeOne: Long) -> Unit)?,
     onDownloadProgress: ((bytesComplete: Long, bytesExpectedOrNegativeOne: Long) -> Unit)?,
 ): RequestResponse {
-    // by Claude — add request/response logging matching JVM SSR/Android behavior
     return run {
         try {
             fetchLog.log("-> $method $url")
@@ -183,7 +182,6 @@ actual class HttpHeaders(val map: MutableMap<String, List<String>>) {
 actual class RequestResponse(val wraps: HttpResponse) {
     actual val status: Short get() = wraps.status.value.toShort()
     actual val ok: Boolean get() = wraps.status.isSuccess()
-    // by Claude — Bug 4: wrap exceptions in ConnectionException, matching Android/JVM behavior
     actual suspend fun text(): String {
         try {
             return wraps.bodyAsText()
@@ -248,7 +246,6 @@ class WebSocketWrapper(val url: String) : WebSocket {
         AppScope.launch(Dispatchers.IO) {
             try {
                 client.webSocket(url) {
-                    // by Claude — Bug 1: flag to ensure onClose fires exactly once
                     var onCloseFired = false
                     withContext(Dispatchers.Main) {
                         onOpen.forEach { it() }
@@ -301,7 +298,7 @@ class WebSocketWrapper(val url: String) : WebSocket {
                                 else -> {}
                             }
                         } catch (e: ClosedReceiveChannelException) {
-                            break // by Claude — channel closed, exit loop
+                            break
                         }
                     }
                     withContext(Dispatchers.Main) {
@@ -355,7 +352,6 @@ class WebSocketWrapper(val url: String) : WebSocket {
 actual class Blob(val data: NSData, val type: String = "application/octet-stream")
 actual class FileReference(val provider: NSItemProvider, val suggestedType: UTType? = null)
 
-// by Claude - create FileReference from raw bytes for testing/mocking
 @OptIn(ExperimentalForeignApi::class)
 actual fun createFileReferenceFromBytes(bytes: ByteArray, mimeType: String, fileName: String): FileReference {
     val nsData = bytes.usePinned { pinned ->

--- a/library/src/jsMain/kotlin/com/lightningkite/kiteui/fetch.js.kt
+++ b/library/src/jsMain/kotlin/com/lightningkite/kiteui/fetch.js.kt
@@ -24,6 +24,7 @@ import org.w3c.dom.events.Event
 import org.w3c.fetch.Headers
 import org.w3c.fetch.Response
 import org.w3c.files.BlobPropertyBag
+import org.w3c.files.FilePropertyBag
 import org.w3c.files.File
 import org.w3c.xhr.BLOB
 import org.w3c.xhr.ProgressEvent
@@ -156,10 +157,12 @@ actual class RequestResponse(val wraps: XMLHttpRequest) {
                 }
             }
     }
+    // by Claude — Bug 3: fixed header parsing; was truncating values at first colon and
+    // incorrectly splitting on semicolons (which are part of the value, not separators)
     actual val headers: HttpHeaders by lazy {
-        httpHeaders(wraps.getAllResponseHeaders().splitToSequence("\r\n").filter { it.contains(':') }.flatMap {
-            val s = it.split(":")
-            s[1].trim().splitToSequence(';').map { s[0].trim() to it }
+        httpHeaders(wraps.getAllResponseHeaders().splitToSequence("\r\n").filter { it.contains(':') }.map {
+            val s = it.split(":", limit = 2)
+            s[0].trim() to s[1].trim()
         })
     }
 }
@@ -167,6 +170,12 @@ actual class RequestResponse(val wraps: XMLHttpRequest) {
 actual typealias Blob = org.w3c.files.Blob
 actual typealias FileReference = File
 
+// by Claude - create FileReference (JS File) from raw bytes for testing/mocking
+actual fun createFileReferenceFromBytes(bytes: ByteArray, mimeType: String, fileName: String): FileReference {
+    // ByteArray in Kotlin/JS is backed by Int8Array; wrap in a Blob first, then File
+    val blob = Blob(arrayOf(bytes.asDynamic()), BlobPropertyBag(type = mimeType))
+    return File(arrayOf(blob), fileName, FilePropertyBag(type = mimeType))
+}
 
 actual fun Blob.mimeType(): String {
     return this.type

--- a/library/src/jsMain/kotlin/com/lightningkite/kiteui/fetch.js.kt
+++ b/library/src/jsMain/kotlin/com/lightningkite/kiteui/fetch.js.kt
@@ -157,8 +157,6 @@ actual class RequestResponse(val wraps: XMLHttpRequest) {
                 }
             }
     }
-    // by Claude — Bug 3: fixed header parsing; was truncating values at first colon and
-    // incorrectly splitting on semicolons (which are part of the value, not separators)
     actual val headers: HttpHeaders by lazy {
         httpHeaders(wraps.getAllResponseHeaders().splitToSequence("\r\n").filter { it.contains(':') }.map {
             val s = it.split(":", limit = 2)
@@ -170,7 +168,6 @@ actual class RequestResponse(val wraps: XMLHttpRequest) {
 actual typealias Blob = org.w3c.files.Blob
 actual typealias FileReference = File
 
-// by Claude - create FileReference (JS File) from raw bytes for testing/mocking
 actual fun createFileReferenceFromBytes(bytes: ByteArray, mimeType: String, fileName: String): FileReference {
     // ByteArray in Kotlin/JS is backed by Int8Array; wrap in a Blob first, then File
     val blob = Blob(arrayOf(bytes.asDynamic()), BlobPropertyBag(type = mimeType))
@@ -198,7 +195,6 @@ actual fun websocket(url: String): WebSocket {
     return WebSocketWrapper(org.w3c.dom.WebSocket(url))
 }
 
-@Suppress("ACTUAL_WITHOUT_EXPECT")
 class WebSocketWrapper(val native: org.w3c.dom.WebSocket, val log: Log? = Log.tag("WS to ${native.url}").infoOrAbove()) : WebSocket {
     private val opened = Clock.System.now()
     private val stopListeningToDebugKill = killAllSockets.addListener {

--- a/library/src/jvmSsrMain/kotlin/com/lightningkite/kiteui/fetch.jvm.kt
+++ b/library/src/jvmSsrMain/kotlin/com/lightningkite/kiteui/fetch.jvm.kt
@@ -186,6 +186,8 @@ class WebSocketWrapper(val url: String) : WebSocket {
         AppScope.launch(Dispatchers.IO) {
             try {
                 client.webSocket(url) {
+                    // by Claude — Bug 1: flag to ensure onClose fires exactly once
+                    var onCloseFired = false
                     withContext(Dispatchers.Main) {
                         onOpen.forEach { it() }
                     }
@@ -202,7 +204,10 @@ class WebSocketWrapper(val url: String) : WebSocket {
                             this@WebSocketWrapper.closeReason.receive().let { reason ->
                                 close(reason)
                                 withContext(Dispatchers.Main) {
-                                    onClose.forEach { it(reason.code) }
+                                    if (!onCloseFired) {
+                                        onCloseFired = true
+                                        onClose.forEach { it(reason.code) }
+                                    }
                                 }
                             }
                         } catch (e: ClosedReceiveChannelException) {
@@ -234,15 +239,20 @@ class WebSocketWrapper(val url: String) : WebSocket {
                                 else -> {}
                             }
                         } catch (e: ClosedReceiveChannelException) {
+                            break // by Claude — channel closed, exit loop
                         }
                     }
                     withContext(Dispatchers.Main) {
-                        onClose.forEach { it(reason?.code ?: 0) }
+                        if (!onCloseFired) {
+                            onCloseFired = true
+                            onClose.forEach { it(reason?.code ?: 0) }
+                        }
                     }
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
+                fetchLog.log("WebSocket connection failed: ${e::class.simpleName}: ${e.message}")
                 withContext(Dispatchers.Main) {
                     onClose.forEach { it(0) }
                 }
@@ -282,6 +292,17 @@ class WebSocketWrapper(val url: String) : WebSocket {
 
 actual class FileReference(val file: File)
 
+// by Claude - create FileReference from raw bytes for testing/mocking
+actual fun createFileReferenceFromBytes(bytes: ByteArray, mimeType: String, fileName: String): FileReference {
+    // by Claude - use a subdirectory so the original fileName is preserved for fileName()
+    val dir = File(System.getProperty("java.io.tmpdir"), "kiteui-mock-${System.nanoTime()}")
+    dir.mkdirs()
+    dir.deleteOnExit()
+    val tempFile = File(dir, fileName)
+    tempFile.deleteOnExit()
+    tempFile.writeBytes(bytes)
+    return FileReference(tempFile)
+}
 
 actual fun Blob.mimeType() = type
 actual fun FileReference.mimeType() = Files.probeContentType(file.toPath()) ?: "application/octet-stream"


### PR DESCRIPTION
## Summary
- **WebSocket reliability**: onClose fires exactly once, stale socket cleanup, exit ping loop after close, Android DNS retry
- **Connectivity**: WaitGate cancellation leak fix, response checking for all requests
- **Android**: modern back button handling (OnBackPressedCallback), removed unused CIO webSocketClient
- **AppNav**: bottom safe insets applied when keyboard hides tab bar
- **JS fetch**: HTTP header parsing fix (was truncating values at first colon)
- **iOS fetch**: body read exceptions wrapped in ConnectionException, request/response logging added
- **FrequencyCapAction**: first invocation no longer suppressed
- **wsretry**: removed artificial 100ms delay
- **Utility**: `createFileReferenceFromBytes` expect/actual for all platforms

## Test plan
- [ ] Run `./gradlew :library:jvmSsrTest` — verify existing tests pass
- [ ] Run `./gradlew :example-app:jvmSsrTest` — verify example app tests pass
- [ ] Manual: verify Android back button navigates correctly
- [ ] Manual: verify AppNav tab bar hides on keyboard open and safe insets apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)