### PR TITLE
Add accessibility properties and view wiring for all platforms

### DIFF
--- a/library-swing/src/jvmMain/kotlin/com/lightningkite/kiteui/views/direct/SwapView.jvmSwing.kt
+++ b/library-swing/src/jvmMain/kotlin/com/lightningkite/kiteui/views/direct/SwapView.jvmSwing.kt
@@ -22,6 +22,8 @@ import javax.swing.JPanel
 import javax.swing.Timer
 
 actual class SwapView actual constructor(context: RContext) : RView(context) {
+    // by Claude - only expose the current (last) child for AI driver snapshots and path resolution
+    override val activeChildren: List<RView> get() = listOfNotNull(children.lastOrNull())
     // Track the current content size to prevent layout jumping during animations
     private var contentPreferredSize: Dimension = Dimension(0, 0)
 

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/AutoCompleteTextField.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/AutoCompleteTextField.android.kt
@@ -43,4 +43,11 @@ actual class AutoCompleteTextField actual constructor(context: RContext): RViewW
             native.setAdapter(KiteUiStringAdapter(native.context, AndroidAppContext.autoCompleteLayoutResource, value))
         }
 
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Checkbox.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Checkbox.android.kt
@@ -48,4 +48,12 @@ actual class Checkbox actual constructor(context: RContext): RView(context) {
     }
 
     actual val checked: MutableReactiveValue<Boolean> = native.contentProperty()
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/CircularProgress.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/CircularProgress.android.kt
@@ -33,6 +33,14 @@ actual class CircularProgress actual constructor(context: RContext) : RView(cont
     actual var ratio: Float
         get() = native.progress /100f
         set(value) { native.setProgress((value * 100)) }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = ratio.toString()
+        set(value) { super.accessibilityValue = value }
+
+    // by Claude
+    override val accessibilityType: String get() = "CircularProgress"
 }
 
 

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/ContainingView.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/ContainingView.android.kt
@@ -56,6 +56,8 @@ actual class RowOrCol actual constructor(context: RContext) : RView(context) {
     override fun applyTheme(theme: ThemeAndBack) { super.applyTheme(theme); val theme = theme.theme
         native.gap = (gap ?: theme.gap).value.roundToInt()
     }
+    // by Claude
+    override val accessibilityType: String get() = if (vertical) "Column" else "Row"
 }
 
 actual class RowCollapsingToColumn actual constructor(context: RContext, breakpoints: List<Dimension>) : RView(context) {

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/ExternalLink.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/ExternalLink.android.kt
@@ -1,11 +1,11 @@
 package com.lightningkite.kiteui.views.direct
 
 import android.widget.FrameLayout
-import com.lightningkite.kiteui.ExternalServices
 import com.lightningkite.kiteui.models.ClickableSemantic
 import com.lightningkite.kiteui.models.DisabledSemantic
 import com.lightningkite.kiteui.models.Theme
 import com.lightningkite.kiteui.models.ThemeAndBack
+import com.lightningkite.kiteui.openTab
 import com.lightningkite.kiteui.views.*
 import kotlinx.coroutines.launch
 
@@ -21,7 +21,7 @@ actual class ExternalLink actual constructor(context: RContext) : RView(context)
                 launch {
                     onNavigate.invoke()
                     value?.let {
-                        ExternalServices.openTab(it)
+                        context.openTab(it)
                     }
                 }
             }
@@ -46,4 +46,11 @@ actual class ExternalLink actual constructor(context: RContext) : RView(context)
     }
 
     override fun applyTheme(theme: ThemeAndBack) = applyThemeWithRipple(theme)
+
+    // by Claude - external link supports click
+    override val accessibilityActions: Set<String> get() = setOf("click")
+    override fun performAccessibilityAction(action: String, value: String?): String? = when (action) {
+        "click" -> { native.performClick(); null }
+        else -> super.performAccessibilityAction(action, value)
+    }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/FormattedTextInput.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/FormattedTextInput.android.kt
@@ -15,8 +15,7 @@ import com.lightningkite.kiteui.models.*
 import com.lightningkite.kiteui.reactive.*
 import com.lightningkite.kiteui.reactive.Action
 import com.lightningkite.kiteui.utils.repairFormatAndPosition
-import com.lightningkite.kiteui.views.RContext
-import com.lightningkite.kiteui.views.RViewWithAction
+import com.lightningkite.kiteui.views.*
 import com.lightningkite.reactive.context.*
 import com.lightningkite.reactive.core.*
 import com.lightningkite.reactive.extensions.*
@@ -166,6 +165,14 @@ actual class FormattedTextInput actual constructor(context: RContext) : RViewWit
             }
         }
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 
     init {
         keyboardHints = KeyboardHints(KeyboardCase.Sentences)

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Link.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Link.android.kt
@@ -61,6 +61,11 @@ actual class Link actual constructor(context: RContext): RView(context) {
     }
 
     override fun applyTheme(theme: ThemeAndBack) = applyThemeWithRipple(theme)
+
+    // by Claude - Link supports click for AI driver navigation
+    override val accessibilityActions: Set<String> get() = setOf("click")
+    override fun performAccessibilityAction(action: String, value: String?): String? = when (action) {
+        "click" -> { native.performClick(); null }
+        else -> super.performAccessibilityAction(action, value)
+    }
 }
-
-

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/LocalDateField.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/LocalDateField.android.kt
@@ -65,4 +65,12 @@ actual class LocalDateField actual constructor(context: RContext) :
     }
 
     override fun applyTheme(theme: ThemeAndBack) = super.applyThemeWithRipple(theme)
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { LocalDate.parse(it) }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { LocalDate.parse(it) }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/LocalDateTimeField.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/LocalDateTimeField.android.kt
@@ -65,4 +65,11 @@ actual class LocalDateTimeField actual constructor(context: RContext) :
 
     override fun applyTheme(theme: ThemeAndBack) = super.applyThemeWithRipple(theme)
 
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { LocalDateTime.parse(it) }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { LocalDateTime.parse(it) }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/LocalTimeField.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/LocalTimeField.android.kt
@@ -7,8 +7,7 @@ import com.lightningkite.kiteui.models.DisabledSemantic
 import com.lightningkite.kiteui.models.Theme
 import com.lightningkite.kiteui.models.ThemeAndBack
 import com.lightningkite.kiteui.reactive.*
-import com.lightningkite.kiteui.views.RContext
-import com.lightningkite.kiteui.views.RViewWithAction
+import com.lightningkite.kiteui.views.*
 import com.lightningkite.reactive.context.*
 import com.lightningkite.reactive.core.*
 import com.lightningkite.reactive.extensions.*
@@ -59,4 +58,12 @@ actual class LocalTimeField actual constructor(context: RContext) :
     }
 
     override fun applyTheme(theme: ThemeAndBack) = super.applyThemeWithRipple(theme)
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { LocalTime.parse(it) }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { LocalTime.parse(it) }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/NumberField.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/NumberField.android.kt
@@ -163,6 +163,14 @@ actual class NumberInput actual constructor(context: RContext) : RViewWithAction
         }
     }
 
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { it.toDoubleOrNull() }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { it.toDoubleOrNull() }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
+
     init {
         keyboardHints = KeyboardHints.decimal
         align = Align.End

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/ProgressBar.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/ProgressBar.android.kt
@@ -76,4 +76,12 @@ actual class ProgressBar actual constructor(context: RContext) : RView(context) 
         set(value) {
             native.progress = (value * 10000).roundToInt()
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = ratio.toString()
+        set(value) { super.accessibilityValue = value }
+
+    // by Claude
+    override val accessibilityType: String get() = "ProgressBar"
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/RadioButton.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/RadioButton.android.kt
@@ -44,4 +44,11 @@ actual class RadioButton actual constructor(context: RContext): RView(context) {
 
     actual val checked: MutableReactiveValue<Boolean> = native.contentProperty()
 
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/RadioToggleButton.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/RadioToggleButton.android.kt
@@ -38,4 +38,12 @@ actual class RadioToggleButton actual constructor(context: RContext) : RView(con
     }
 
     override fun applyTheme(theme: ThemeAndBack) = super.applyThemeWithRipple(theme)
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.android.kt
@@ -46,6 +46,14 @@ actual abstract class RawImageViewLike constructor(
     actual val scaleType: ImageScaleType,
 ) : RView(context){
     actual abstract val state: Reactive<Unit>
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = description
+        set(value) { super.accessibilityValue = value }
+
+    // by Claude
+    override val accessibilityType: String get() = "Image"
 }
 
 

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Select.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Select.android.kt
@@ -22,6 +22,7 @@ import com.lightningkite.reactive.core.*
 import com.lightningkite.reactive.extensions.*
 import com.lightningkite.reactive.lensing.*
 import com.lightningkite.readable.*
+import kotlinx.coroutines.launch
 
 actual class Select actual constructor(context: RContext): RView(context) {
     override val native = Spinner(context.activity).apply {
@@ -73,6 +74,9 @@ actual class Select actual constructor(context: RContext): RView(context) {
 
         background = layerDrawable
     }
+
+    private var _accessibilityRenderedValue: String? = null  // by Claude
+    private var _accessibilitySetter: ((String) -> Unit)? = null  // by Claude
 
     actual fun <T> bind(
         edits: MutableReactive<T>,
@@ -147,8 +151,15 @@ actual class Select actual constructor(context: RContext): RView(context) {
                 suppressChange = false
             }
         }
+        _accessibilitySetter = { text ->  // by Claude
+            @Suppress("UNCHECKED_CAST")
+            val item = list.firstOrNull { render(it) == text }
+                ?: throw IllegalArgumentException("No option matching '$text'")
+            launch { edits set item }
+        }
         reactiveScope {
             val currentlySelected = edits()
+            _accessibilityRenderedValue = render(currentlySelected)  // by Claude
             val index = list.indexOf(currentlySelected)
             if (index != -1 && !suppressChange) {
                 suppressChange = true
@@ -156,6 +167,22 @@ actual class Select actual constructor(context: RContext): RView(context) {
                 suppressChange = false
             }
         }
+    }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = _accessibilityRenderedValue
+        set(value) {
+            val setter = _accessibilitySetter ?: throw IllegalStateException("Select not bound")
+            setter(value ?: throw IllegalArgumentException("Cannot set null on Select"))
+        }
+
+    // by Claude - select supports click and setValue
+    override val accessibilityActions: Set<String> get() = setOf("click", "setValue")
+    override fun performAccessibilityAction(action: String, value: String?): String? = when (action) {
+        "click" -> { native.performClick(); null }
+        "setValue" -> { accessibilityValue = value; null }
+        else -> super.performAccessibilityAction(action, value)
     }
 }
 

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Slider.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Slider.android.kt
@@ -131,4 +131,12 @@ actual class Slider actual constructor(context: RContext) : RView(context) {
         nativeSeekBar.progressBackgroundTintList = android.content.res.ColorStateList.valueOf(t.background.closestColor().colorInt())
         nativeSeekBar.thumbTintList = android.content.res.ColorStateList.valueOf(t.foreground.closestColor().colorInt())
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNonNullValue(value)
+        set(v) = writeNonNullValue(value, v) { it.toFloatOrNull() ?: throw IllegalArgumentException("Cannot parse '$it' as Float") }
+    override val accessibilityActions get() = SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNonNullSetValueAction(this.value, { it.toFloatOrNull() ?: throw IllegalArgumentException("Cannot parse '$it' as Float") }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/SwapView.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/SwapView.android.kt
@@ -23,6 +23,8 @@ import com.lightningkite.readable.*
 
 actual class SwapView actual constructor(context: RContext) : RView(context) {
     override val native = FrameLayout(context.activity)
+    // by Claude - only expose the current (last) child for AI driver snapshots and path resolution
+    override val activeChildren: List<RView> get() = listOfNotNull(children.lastOrNull())
 
     companion object {
         val swapTimeMakeViewPerformance = PerformanceInfo("swapTimeMakeView")

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Switch.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Switch.android.kt
@@ -91,4 +91,11 @@ actual class Switch actual constructor(context: RContext): RView(context) {
 
     actual val checked: MutableReactiveValue<Boolean> = native.contentProperty()
 
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TextArea.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TextArea.android.kt
@@ -116,4 +116,12 @@ actual class TextArea actual constructor(context: RContext) : RViewWithAction(co
         set(value) {
             native.setTextSize(TypedValue.COMPLEX_UNIT_PX, value.value.toFloat())
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TextField.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TextField.android.kt
@@ -136,6 +136,14 @@ actual open class TextInput actual constructor(context: RContext) : RViewWithAct
         }
     }
 
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
+
     init {
         keyboardHints = KeyboardHints(KeyboardCase.Sentences)
     }

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.android.kt
@@ -98,6 +98,14 @@ actual class TextView actual constructor(context: RContext) :
         native.setTextSize(TypedValue.COMPLEX_UNIT_PX, theme.font.size.value)
         applyAlign(_align ?: theme.font.align)
     }
+    // by Claude
+    override var accessibilityValue: String?
+        get() = content
+        set(value) { super.accessibilityValue = value }
+
+    // by Claude
+    override val accessibilityType: String get() = "Text"
+
     actual fun setBasicHtmlContent(html: String) {
         if(html.contains("<a")) {
             native.movementMethod = LinkMovementMethod.getInstance()

--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/ToggleButton.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/ToggleButton.android.kt
@@ -38,4 +38,12 @@ actual class ToggleButton actual constructor(context: RContext) : RView(context)
     }
 
     override fun applyTheme(theme: ThemeAndBack) = applyThemeWithRipple(theme)
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/RView.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/RView.commonHtml.kt
@@ -55,6 +55,10 @@ actual abstract class RView actual constructor(context: RContext) : RViewHelper(
             else native.classes.remove("noInteraction")
         }
 
+    // by Claude - controls like Button store enabled in native.attributes.disabled, not ignoreInteraction
+    override val accessibilityEnabled: Boolean
+        get() = !ignoreInteraction && native.attributes.disabled != true
+
     override var debugName: String?
         get() = super.debugName
         set(value) {

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/AutoCompleteTextFIeld.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/AutoCompleteTextFIeld.commonHtml.kt
@@ -50,6 +50,14 @@ actual class AutoCompleteTextField actual constructor(context: RContext) : RView
             native.style.fontSize = value.value.toString()
         }
 
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
+
     actual var suggestions: List<String> = listOf()
         set(value) {
             field = value

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/Checkbox.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/Checkbox.commonHtml.kt
@@ -31,4 +31,12 @@ actual class Checkbox actual constructor(context: RContext) : RView(context) {
         set(value) {
             native.attributes.disabled = !value
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/ContainingView.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/ContainingView.commonHtml.kt
@@ -84,6 +84,9 @@ actual class Frame actual constructor(context: RContext) : RView(context) {
 }
 
 actual class RowOrCol actual constructor(context: RContext) : RView(context) {
+    // by Claude
+    override val accessibilityType: String get() = if (vertical) "Column" else "Row"
+
     init {
         native.tag = "div"
         native.style.flexDirection = "column"

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/ExternalLink.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/ExternalLink.commonHtml.kt
@@ -40,4 +40,11 @@ actual class ExternalLink actual constructor(context: RContext) : RView(context)
             launch { action() }
         }
     }
+
+    // by Claude - ExternalLink supports click for AI driver
+    override val accessibilityActions: Set<String> get() = setOf("click")
+    override fun performAccessibilityAction(action: String, value: String?): String? = when (action) {
+        "click" -> { native.click(); null }
+        else -> super.performAccessibilityAction(action, value)
+    }
 }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/FormattedTextInput.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/FormattedTextInput.commonHtml.kt
@@ -102,6 +102,14 @@ actual class FormattedTextInput actual constructor(context: RContext) : RViewWit
     actual var enabled: Boolean
         get() = !(native.attributes.disabled ?: false)
         set(value) { native.attributes.disabled = !value }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }
 
 expect val FormattedTextInput.selectionStart: Int?

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/Link.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/Link.commonHtml.kt
@@ -68,4 +68,21 @@ actual class Link actual constructor(context: RContext) : RView(context) {
         set(value) {
             native.attributes.disabled = !value
         }
+
+    // by Claude - Link supports click for AI driver navigation
+    override val accessibilityActions: Set<String> get() = setOf("click")
+    override fun performAccessibilityAction(action: String, value: String?): String? = when (action) {
+        "click" -> {
+            onClick?.let { launch { it() } }
+            val destination = to?.invoke()
+            if (destination != null) {
+                launch {
+                    onNavigate?.invoke()
+                    if (resetsStack) onNavigator.reset(destination) else onNavigator.navigate(destination)
+                }
+            }
+            null
+        }
+        else -> super.performAccessibilityAction(action, value)
+    }
 }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/LocalDateTimeField.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/LocalDateTimeField.commonHtml.kt
@@ -72,6 +72,14 @@ actual class LocalDateTimeField actual constructor(context: RContext) : RViewWit
                 native.attributes.maxString = null
             }
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { LocalDateTime.parse(it) }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { LocalDateTime.parse(it) }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }
 
 
@@ -136,6 +144,14 @@ actual class LocalDateField actual constructor(context: RContext) : RViewWithAct
                 native.attributes.maxString = null
             }
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { LocalDate.parse(it) }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { LocalDate.parse(it) }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }
 
 actual class LocalTimeField actual constructor(context: RContext) : RViewWithAction(context) {
@@ -199,6 +215,14 @@ actual class LocalTimeField actual constructor(context: RContext) : RViewWithAct
                 native.attributes.maxString = null
             }
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { LocalTime.parse(it) }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { LocalTime.parse(it) }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }
 
 //@Suppress("ACTUAL_WITHOUT_EXPECT")

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/NumberField.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/NumberField.commonHtml.kt
@@ -38,8 +38,11 @@ actual class NumberInput actual constructor(context: RContext) : RViewWithAction
         override var value: Double?
             get() = native.attributes.valueString?.filter { it.isDigit() || it in setOf('-', '.') }?.toDoubleOrNull()
             set(value) {
-                if(native.attributes.valueString != value?.commaString())
+                if(native.attributes.valueString != value?.commaString()) {
                     native.attributes.valueString = value?.commaString()
+                    // by Claude - must notify listeners so bind propagates programmatic setValue
+                    invokeAllListeners()
+                }
             }
     }
 
@@ -143,6 +146,14 @@ actual class NumberInput actual constructor(context: RContext) : RViewWithAction
     actual var enabled: Boolean
         get() = !(native.attributes.disabled ?: false)
         set(value) { native.attributes.disabled = !value }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { it.toDoubleOrNull() }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { it.toDoubleOrNull() }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }
 
 expect val NumberInput.selectionStart: Int?

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/ProgressBar.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/ProgressBar.commonHtml.kt
@@ -15,4 +15,12 @@ actual class ProgressBar actual constructor(context: RContext): RView(context) {
         set(value) {
             native.attributes.valueDouble = value.toDouble()
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = ratio.toString()
+        set(value) { super.accessibilityValue = value }
+
+    // by Claude
+    override val accessibilityType: String get() = "ProgressBar"
 }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/RadioButton.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/RadioButton.commonHtml.kt
@@ -29,4 +29,12 @@ actual class RadioButton actual constructor(context: RContext) : RView(context) 
         set(value) {
             native.attributes.disabled = !value
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/RadioToggleButton.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/RadioToggleButton.commonHtml.kt
@@ -66,4 +66,12 @@ actual class RadioToggleButton actual constructor(context: RContext) : RView(con
         set(value) {
             input.attributes.disabled = !value
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.commonHtml.kt
@@ -53,6 +53,14 @@ actual abstract class RawImageViewLike(
         }
     }
 
+    // by Claude
+    override var accessibilityValue: String?
+        get() = description
+        set(value) { super.accessibilityValue = value }
+
+    // by Claude
+    override val accessibilityType: String get() = "Image"
+
     protected fun ImageSource?.toUrl(): String? {
         // by Claude - revoke previous blob URL before creating a new one
         currentBlobUrl?.let { revokeObjectURL(it) }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/Select.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/Select.commonHtml.kt
@@ -10,6 +10,7 @@ import com.lightningkite.reactive.core.*
 import com.lightningkite.reactive.extensions.*
 import com.lightningkite.reactive.lensing.*
 import com.lightningkite.readable.*
+import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.milliseconds
 
 
@@ -18,6 +19,9 @@ actual class Select actual constructor(context: RContext) : RView(context) {
         native.tag = "select"
         native.classes.add("editable")
     }
+
+    private var _accessibilityRenderedValue: String? = null  // by Claude
+    private var _accessibilitySetter: ((String) -> Unit)? = null  // by Claude
 
     actual fun <T> bind(
         edits: MutableReactive<T>,
@@ -43,6 +47,7 @@ actual class Select actual constructor(context: RContext) : RView(context) {
         var alreadyHandled = false
         reactiveScope {
             val newValue = edits()
+            _accessibilityRenderedValue = render(newValue)  // by Claude
             val list = data.state.getOrNull() ?: listOf()
             if (alreadyHandled) return@reactiveScope
             alreadyHandled = true
@@ -59,6 +64,28 @@ actual class Select actual constructor(context: RContext) : RView(context) {
         native.addEventListener("change") {
             setAction.startAction(this)
         }
+        _accessibilitySetter = { text ->  // by Claude
+            @Suppress("UNCHECKED_CAST")
+            val item = list.firstOrNull { render(it) == text }
+                ?: throw IllegalArgumentException("No option matching '$text'")
+            launch { edits set item }
+        }
+    }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = _accessibilityRenderedValue
+        set(value) {
+            val setter = _accessibilitySetter ?: throw IllegalStateException("Select not bound")
+            setter(value ?: throw IllegalArgumentException("Cannot set null on Select"))
+        }
+
+    // by Claude - select supports click and setValue
+    override val accessibilityActions: Set<String> get() = setOf("click", "setValue")
+    override fun performAccessibilityAction(action: String, value: String?): String? = when (action) {
+        "click" -> null  // click is handled at the native level
+        "setValue" -> { accessibilityValue = value; null }
+        else -> super.performAccessibilityAction(action, value)
     }
 
     actual var enabled: Boolean

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/Slider.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/Slider.commonHtml.kt
@@ -74,4 +74,12 @@ actual class Slider actual constructor(context: RContext) : RView(context) {
         set(value) {
             native.attributes.disabled = !value
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNonNullValue(value)
+        set(v) = writeNonNullValue(value, v) { it.toFloatOrNull() ?: throw IllegalArgumentException("Cannot parse '$it' as Float") }
+    override val accessibilityActions get() = SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNonNullSetValueAction(this.value, { it.toFloatOrNull() ?: throw IllegalArgumentException("Cannot parse '$it' as Float") }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/SwapView.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/SwapView.commonHtml.kt
@@ -6,6 +6,9 @@ import com.lightningkite.kiteui.views.*
 
 
 actual class SwapView actual constructor(context: RContext) : RView(context) {
+    // by Claude - only expose the current (last) child for AI driver snapshots and path resolution
+    override val activeChildren: List<RView> get() = listOfNotNull(children.lastOrNull())
+
     init {
         native.tag = "div"
         native.classes.add("kiteui-stack")

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/Switch.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/Switch.commonHtml.kt
@@ -26,4 +26,12 @@ actual class Switch actual constructor(context: RContext) : RView(context) {
         set(value) {
             native.attributes.disabled = !value
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/TextArea.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/TextArea.commonHtml.kt
@@ -71,4 +71,12 @@ actual class TextArea actual constructor(context: RContext) : RViewWithAction(co
     actual var enabled: Boolean
         get() = !(textarea.attributes.disabled ?: false)
         set(value) { textarea.attributes.disabled = !value }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/TextField.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/TextField.commonHtml.kt
@@ -63,4 +63,11 @@ actual class TextInput actual constructor(context: RContext) : RViewWithAction(c
         applyAlign(_align ?: theme.theme.font.align)
     }
 
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.commonHtml.kt
@@ -78,5 +78,13 @@ actual class TextView actual constructor(context: RContext) : RView(context) {
         native.style.whiteSpace = "pre-line"
         native.innerHtmlUnsafe = html.parseMPNodes().onEach { it.secure() }.joinToString(" ")
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = content
+        set(value) { super.accessibilityValue = value }
+
+    // by Claude
+    override val accessibilityType: String get() = "Text"
 }
 

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/ToggleButton.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/direct/ToggleButton.commonHtml.kt
@@ -69,4 +69,12 @@ actual class ToggleButton actual constructor(context: RContext) : RView(context)
         set(value) {
             input.attributes.disabled = !value
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/AccessibilityHelpers.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/AccessibilityHelpers.kt
@@ -1,0 +1,93 @@
+// by Claude - shared helpers for accessibility value/action overrides across all platforms.
+// Eliminates duplication of identical logic in Android, iOS, and commonHtml view implementations.
+package com.lightningkite.kiteui.views
+
+import com.lightningkite.reactive.core.MutableReactiveValue
+
+// --- Action set constants ---
+
+val CLICK_AND_SET_VALUE_ACTIONS: Set<String> = setOf("click", "setValue")
+val SET_VALUE_ACTIONS: Set<String> = setOf("setValue")
+
+// --- Boolean controls (Checkbox, Switch, RadioButton, RadioToggleButton, ToggleButton) ---
+
+fun readBooleanValue(prop: MutableReactiveValue<Boolean>): String =
+    prop.value.toString()
+
+fun writeBooleanValue(prop: MutableReactiveValue<Boolean>, value: String?) {
+    prop.value = when (value?.lowercase()) {
+        "true" -> true
+        "false" -> false
+        else -> throw IllegalArgumentException("Expected 'true' or 'false', got '$value'")
+    }
+}
+
+fun performBooleanAction(
+    prop: MutableReactiveValue<Boolean>,
+    action: String,
+    value: String?,
+    fallback: (String, String?) -> String?
+): String? = when (action) {
+    "click" -> { prop.value = !prop.value; null }
+    "setValue" -> { writeBooleanValue(prop, value); null }
+    else -> fallback(action, value)
+}
+
+// --- String controls (TextField, TextArea, AutoCompleteTextField, FormattedTextInput) ---
+
+fun readStringValue(prop: MutableReactiveValue<String>): String =
+    prop.value
+
+fun writeStringValue(prop: MutableReactiveValue<String>, value: String?) {
+    prop.value = value ?: ""
+}
+
+fun performStringSetValueAction(
+    prop: MutableReactiveValue<String>,
+    action: String,
+    value: String?,
+    fallback: (String, String?) -> String?
+): String? = when (action) {
+    "setValue" -> { writeStringValue(prop, value); null }
+    else -> fallback(action, value)
+}
+
+// --- Nullable-parseable controls (NumberField, Slider, LocalDate/Time/DateTime fields) ---
+
+fun <T> readNullableValue(prop: MutableReactiveValue<T?>): String? =
+    prop.value?.toString()
+
+fun <T> writeNullableValue(prop: MutableReactiveValue<T?>, value: String?, parser: (String) -> T?) {
+    prop.value = value?.let(parser)
+}
+
+fun <T> performNullableSetValueAction(
+    prop: MutableReactiveValue<T?>,
+    parser: (String) -> T?,
+    action: String,
+    value: String?,
+    fallback: (String, String?) -> String?
+): String? = when (action) {
+    "setValue" -> { writeNullableValue(prop, value, parser); null }
+    else -> fallback(action, value)
+}
+
+// --- Non-nullable parseable controls (Slider) ---
+
+fun <T> readNonNullValue(prop: MutableReactiveValue<T>): String =
+    prop.value.toString()
+
+fun <T> writeNonNullValue(prop: MutableReactiveValue<T>, value: String?, parser: (String) -> T) {
+    prop.value = parser(value ?: throw IllegalArgumentException("Cannot set null value"))
+}
+
+fun <T> performNonNullSetValueAction(
+    prop: MutableReactiveValue<T>,
+    parser: (String) -> T,
+    action: String,
+    value: String?,
+    fallback: (String, String?) -> String?
+): String? = when (action) {
+    "setValue" -> { writeNonNullValue(prop, value, parser); null }
+    else -> fallback(action, value)
+}

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/AriaDescription.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/AriaDescription.kt
@@ -1,0 +1,97 @@
+// by Claude - aria description modifier and AI path utilities
+package com.lightningkite.kiteui.views
+
+/**
+ * Accessible description for this view.
+ * On Android, sets contentDescription; on iOS, sets accessibilityLabel;
+ * on Web, sets the aria-label attribute.
+ * Also used as a fallback ID by the AI driver when no explicit testId is set.
+ */
+var RView.ariaDescription: String?
+    get() = (this as RViewHelper).ariaDescription
+    set(value) {
+        (this as RViewHelper).ariaDescription = value
+    }
+
+/**
+ * Modifier to set an aria description on the next view element.
+ *
+ * Example:
+ * ```kotlin
+ * ariaDescription("Sign in button") - button {
+ *     text("Sign In")
+ * }
+ * ```
+ */
+@ViewModifierDsl3
+fun ViewWriter.ariaDescription(value: String): ViewWriter = also {
+    it.beforeNextElementSetup {
+        ariaDescription = value
+    }
+}
+
+/**
+ * Converts a human-readable string to a camelCase AI path segment.
+ * Splits on whitespace, hyphens, and underscores.
+ * E.g. "Sign In Button" → "signInButton"
+ */
+fun String.toAiId(): String =
+    trim().split(Regex("[\\s\\-_]+"))
+        .filter { it.isNotEmpty() }
+        .mapIndexed { i, word ->
+            if (i == 0) word.lowercase()
+            else word.lowercase().replaceFirstChar { it.uppercaseChar() }
+        }
+        .joinToString("")
+
+/**
+ * Resolves a slash-separated path from this view's subtree.
+ * - ".." moves to parent
+ * - Numeric segment selects child by index
+ * - Named segment matches debugName or ariaDescription.toAiId()
+ *
+ * If the first segment is a name and doesn't match a direct child, deep-searches for it
+ * as an anchor, then follows remaining segments from there. This supports the compact
+ * snapshot format where named elements reset their path prefix.
+ */
+// by Claude - anchored path resolution: deep-search for named first segment, then follow remaining path
+fun RView.resolveAiPath(path: String): RView? {
+    val segments = path.split("/").filter { it.isNotEmpty() }
+
+    // Try direct path resolution using activeChildren to skip stale SwapView children
+    var current: RView = this
+    var resolved = true
+    for (segment in segments) {
+        val next = when {
+            segment == ".." -> current.parent
+            segment.all(Char::isDigit) -> current.activeChildren.getOrNull(segment.toInt())
+            else -> current.activeChildren.find {
+                it.debugName == segment || (it as? RViewHelper)?.ariaDescription?.toAiId() == segment
+            }
+        }
+        if (next == null) { resolved = false; break }
+        current = next
+    }
+    if (resolved) return current
+
+    // Fallback: if the first segment is a name, deep-search for it as an anchor,
+    // then follow remaining segments from there
+    if (segments.isNotEmpty() && !segments[0].all(Char::isDigit) && segments[0] != "..") {
+        val anchor = deepSearchByName(segments[0]) ?: return null
+        if (segments.size == 1) return anchor
+        // Follow remaining segments from the anchor
+        return anchor.resolveAiPath(segments.drop(1).joinToString("/"))
+    }
+
+    return null
+}
+
+// by Claude - depth-first search for a view by debugName or ariaDescription
+private fun RView.deepSearchByName(name: String): RView? {
+    // by Claude - use activeChildren to skip stale SwapView children
+    for (child in activeChildren) {
+        if (child.debugName == name || (child as? RViewHelper)?.ariaDescription?.toAiId() == name) return child
+        child.deepSearchByName(name)?.let { return it }
+    }
+    return null
+}

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/AriaDescription.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/AriaDescription.kt
@@ -2,18 +2,6 @@
 package com.lightningkite.kiteui.views
 
 /**
- * Accessible description for this view.
- * On Android, sets contentDescription; on iOS, sets accessibilityLabel;
- * on Web, sets the aria-label attribute.
- * Also used as a fallback ID by the AI driver when no explicit testId is set.
- */
-var RView.ariaDescription: String?
-    get() = (this as RViewHelper).ariaDescription
-    set(value) {
-        (this as RViewHelper).ariaDescription = value
-    }
-
-/**
  * Modifier to set an aria description on the next view element.
  *
  * Example:

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/RView.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/RView.kt
@@ -146,6 +146,13 @@ abstract class RViewWithAction(context: RContext) : RView(context) {
         actionStatusRemove?.invoke()
         actionStatusRemove = value?.let { listenForWorking(it) }
     }
+
+    // by Claude - views with an action support clicking by default
+    override val accessibilityActions: Set<String> get() = setOf("click")
+    override fun performAccessibilityAction(action: String, value: String?): String? = when (action) {
+        "click" -> { this.action?.startAction(this); null }
+        else -> super.performAccessibilityAction(action, value)
+    }
 }
 
 /**
@@ -176,6 +183,13 @@ abstract class RViewWithSecondaryAction(context: RContext) : RViewWithAction(con
     open fun secondaryActionSet(value: Action?) {
         secondaryActionStatusRemove?.invoke()
         secondaryActionStatusRemove = value?.let { listenForWorking(it) }
+    }
+
+    // by Claude - adds longClick to the action set
+    override val accessibilityActions: Set<String> get() = setOf("click", "longClick")
+    override fun performAccessibilityAction(action: String, value: String?): String? = when (action) {
+        "longClick" -> { this.secondaryAction?.startAction(this); null }
+        else -> super.performAccessibilityAction(action, value)
     }
 }
 

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/RViewHelper.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/RViewHelper.kt
@@ -67,6 +67,29 @@ abstract class RViewHelper(override val context: RContext) : ViewWriter() {
     override val representsView: RView get() = this as RView
 
     /**
+     * Used for testing and AI services to get or set the value of a field without interacting with the UI.
+     * Returns null by default; override in specific view classes (TextInput, Checkbox, etc.) to expose the value.
+     */
+    open var accessibilityValue: String?
+        get() = null
+        set(value) {
+            throw IllegalArgumentException("You cannot set the value in this view.")
+        }
+
+    // by Claude - semantic type for AI and accessibility; defaults to class simpleName
+    open val accessibilityType: String get() = this::class.simpleName ?: "View"
+
+    // by Claude - set of action names this view supports (e.g. "click", "setValue")
+    open val accessibilityActions: Set<String> get() = emptySet()
+
+    // by Claude - whether this view is enabled for interaction; override in controls with their own enabled property
+    open val accessibilityEnabled: Boolean get() = !ignoreInteraction
+
+    // by Claude - execute an accessibility action; returns null on success, error message on failure
+    open fun performAccessibilityAction(action: String, value: String? = null): String? =
+        "Action '$action' not supported on ${accessibilityType}"
+
+    /**
      * Flag indicating whether this view has been shut down.
      * Once true, operations on this view will log warnings and may not function correctly.
      */
@@ -327,6 +350,14 @@ abstract class RViewHelper(override val context: RContext) : ViewWriter() {
      * to modify the child list.
      */
     val children: List<RView> get() = internalChildren
+
+    /**
+     * Children that should be considered "active" for AI driver snapshots and path resolution.
+     * Defaults to [children]. Overridden by [SwapView][com.lightningkite.kiteui.views.direct.SwapView]
+     * to exclude stale children that are animating out, returning only the current view.
+     */
+    // by Claude - filters out stale SwapView children for accurate AI driver snapshots
+    open val activeChildren: List<RView> get() = children
 
     /**
      * Called before a child view is added. This sets the child's parent reference.
@@ -682,6 +713,9 @@ abstract class RViewHelper(override val context: RContext) : ViewWriter() {
 
     // by Claude - allows setting semantic HTML tag from common code for SEO
     open var htmlElementTag: String? = null
+
+    // by Claude - accessible description for this view, used by screen readers and AI automation
+    open var ariaDescription: String? = null
 
     /**
      * Convenience operator allowing actions to be invoked with this view as the context.

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/AutoCompleteTextField.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/AutoCompleteTextField.ios.kt
@@ -65,7 +65,12 @@ actual class AutoCompleteTextField actual constructor(context: RContext) : RView
     actual val content: MutableReactiveValue<String> = object : MutableReactiveValue<String> {
         override var value: String
             get() = textField.text ?: ""
-            set(value) { textField.text = value }
+            set(value) {
+                if (textField.text == value) return
+                textField.text = value
+                // by Claude - fire change event so reactive listeners are notified on programmatic updates
+                textField.sendActionsForControlEvents(UIControlEventEditingChanged)
+            }
         override fun addListener(listener: () -> Unit): () -> Unit {
             return textField.onEvent(this@AutoCompleteTextField, UIControlEventEditingChanged, listener)
         }
@@ -137,5 +142,13 @@ actual class AutoCompleteTextField actual constructor(context: RContext) : RView
             }
         }
     actual var suggestions: List<String> = listOf()
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }
 

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/Checkbox.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/Checkbox.ios.kt
@@ -48,4 +48,12 @@ actual class Checkbox actual constructor(context: RContext) : RView(context) {
             _checked.value = !_checked.value
         })
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CircularProgress.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/CircularProgress.ios.kt
@@ -13,4 +13,12 @@ import platform.UIKit.UIView
 actual class CircularProgress actual constructor(context: RContext) : RView(context) {
     override val native = UIView(CGRectMake(0.0, 0.0, 0.0, 0.0))
     actual var ratio: Float = 0f
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = ratio.toString()
+        set(value) { super.accessibilityValue = value }
+
+    // by Claude
+    override val accessibilityType: String get() = "CircularProgress"
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ContainingView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ContainingView.ios.kt
@@ -15,7 +15,9 @@ import platform.UIKit.UIView
 
 actual class RowOrCol actual constructor(context: RContext) : RView(context) {
     override val native = LinearLayout()
-    
+
+    // by Claude
+    override val accessibilityType: String get() = if (vertical) "Column" else "Row"
 
     actual var vertical: Boolean
         get() = native.horizontal.not()

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ExternalLink.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ExternalLink.ios.kt
@@ -57,4 +57,11 @@ actual class ExternalLink actual constructor(context: RContext): RView(context) 
         if(native.focused) t = t[FocusSemantic]
         return super.applyState(t)
     }
+
+    // by Claude - ExternalLink supports click for AI driver
+    override val accessibilityActions: Set<String> get() = setOf("click")
+    override fun performAccessibilityAction(action: String, value: String?): String? = when (action) {
+        "click" -> { native.sendActionsForControlEvents(UIControlEventTouchUpInside); null }
+        else -> super.performAccessibilityAction(action, value)
+    }
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/FormattedTextInput.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/FormattedTextInput.ios.kt
@@ -96,8 +96,11 @@ actual class FormattedTextInput actual constructor(context: RContext) : RViewWit
             get() = (textField.text ?: "").filter(isRawData)
             set(value) {
                 val formatted = formatter(value.filter(isRawData))
-                if (textField.text != formatted)
+                if (textField.text != formatted) {
                     textField.text = formatted
+                    // by Claude - fire change event so reactive listeners are notified on programmatic updates
+                    textField.sendActionsForControlEvents(UIControlEventEditingChanged)
+                }
             }
 
         override fun addListener(listener: () -> Unit): () -> Unit {
@@ -181,6 +184,14 @@ actual class FormattedTextInput actual constructor(context: RContext) : RViewWit
             textField.enabled = value
             refreshTheming()
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 
     init {
         onRemove(textField.observe("highlighted", { refreshTheming() }))

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/Link.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/Link.ios.kt
@@ -66,5 +66,21 @@ actual class Link actual constructor(context: RContext): RView(context) {
         if(native.focused) t = t[FocusSemantic]
         return super.applyState(t)
     }
+
+    // by Claude - Link supports click for AI driver navigation
+    override val accessibilityActions: Set<String> get() = setOf("click")
+    override fun performAccessibilityAction(action: String, value: String?): String? = when (action) {
+        "click" -> {
+            onClick?.let { launch { it() } }
+            to?.invoke()?.let { destination ->
+                launch {
+                    onNavigate?.invoke()
+                    if (resetsStack) onNavigator.reset(destination) else onNavigator.navigate(destination)
+                }
+            }
+            null
+        }
+        else -> super.performAccessibilityAction(action, value)
+    }
 }
 

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/LocalDateTimeField.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/LocalDateTimeField.ios.kt
@@ -95,6 +95,14 @@ actual class LocalDateField actual constructor(context: RContext) : RViewWithAct
         if(textField.focused) t = t[FocusSemantic]
         return super.applyState(t)
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { LocalDate.parse(it) }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { LocalDate.parse(it) }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }
 
 actual class LocalTimeField actual constructor(context: RContext) : RViewWithAction(context) {
@@ -178,6 +186,14 @@ actual class LocalTimeField actual constructor(context: RContext) : RViewWithAct
         if(textField.focused) t = t[FocusSemantic]
         return super.applyState(t)
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { LocalTime.parse(it) }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { LocalTime.parse(it) }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }
 
 actual class LocalDateTimeField actual constructor(context: RContext) : RViewWithAction(context) {
@@ -258,6 +274,14 @@ actual class LocalDateTimeField actual constructor(context: RContext) : RViewWit
         if(textField.focused) t = t[FocusSemantic]
         return super.applyState(t)
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { LocalDateTime.parse(it) }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { LocalDateTime.parse(it) }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }
 
 

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/NumberField.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/NumberField.ios.kt
@@ -113,8 +113,11 @@ actual class NumberInput actual constructor(context: RContext) : RViewWithAction
         override var value: Double?
             get() = (textField.text ?: "").filter { it.isDigit() || it == '.' }.toDoubleOrNull()
             set(value) {
-                if(textField.text != (value?.commaString() ?: ""))
+                if(textField.text != (value?.commaString() ?: "")) {
                     textField.text = value?.commaString() ?: ""
+                    // by Claude - fire change event so reactive listeners are notified on programmatic updates
+                    textField.sendActionsForControlEvents(UIControlEventEditingChanged)
+                }
             }
         override fun addListener(listener: () -> Unit): () -> Unit {
             return textField.onEvent(this@NumberInput, UIControlEventEditingChanged, listener)
@@ -207,4 +210,12 @@ actual class NumberInput actual constructor(context: RContext) : RViewWithAction
         if(textField.focused) t = t[FocusSemantic]
         return super.applyState(t)
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNullableValue(content)
+        set(value) = writeNullableValue(content, value) { it.toDoubleOrNull() }
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNullableSetValueAction(content, { it.toDoubleOrNull() }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ProgressBar.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ProgressBar.ios.kt
@@ -19,6 +19,14 @@ actual class ProgressBar actual constructor(context: RContext) : RView(context) 
         native.progressLayer.tintColor = theme[CardSemantic].theme.foreground.closestColor().toUiColor()
     }
     actual var ratio by native::progress
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = ratio.toString()
+        set(value) { super.accessibilityValue = value }
+
+    // by Claude
+    override val accessibilityType: String get() = "ProgressBar"
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RadioButton.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RadioButton.ios.kt
@@ -50,4 +50,12 @@ actual class RadioButton actual constructor(context: RContext) : RView(context) 
             _checked.value = !_checked.value || _checked.value
         })
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RadioToggleButton.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RadioToggleButton.ios.kt
@@ -38,4 +38,12 @@ actual class RadioToggleButton actual constructor(context: RContext) : RView(con
         if(native.focused) t = t[FocusSemantic]
         return super.applyState(t)
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/RawImageView.ios.kt
@@ -49,6 +49,14 @@ constructor(
     }
 
     override val disableBackground = true
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = description
+        set(value) { super.accessibilityValue = value }
+
+    // by Claude
+    override val accessibilityType: String get() = "Image"
 }
 
 // Helper function to create an animated UIImage from data (supports GIF)

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/Select.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/Select.ios.kt
@@ -27,6 +27,8 @@ actual class Select actual constructor(context: RContext): RView(context) {
         textField.inputView = UIPickerView()
     }
 
+    private var _accessibilitySetter: ((String) -> Unit)? = null  // by Claude
+
     actual fun <T> bind(
         edits: MutableReactive<T>,
         data: Reactive<List<T>>,
@@ -70,6 +72,12 @@ actual class Select actual constructor(context: RContext): RView(context) {
             picker.setDataSource(null)
             picker.setDelegate(null)
         }
+        _accessibilitySetter = { text ->  // by Claude
+            @Suppress("UNCHECKED_CAST")
+            val item = source.list.firstOrNull { render(it) == text }
+                ?: throw IllegalArgumentException("No option matching '$text'")
+            launch { edits set item }
+        }
     }
 
     var fontAndStyle: FontAndStyle? = null
@@ -88,6 +96,22 @@ actual class Select actual constructor(context: RContext): RView(context) {
             it.font.get(it.size.value * preferredScaleFactor(), it.weight.toUIFontWeight(), it.italic)
         } ?: UIFont.systemFontOfSize(16.0)
         textField.textAlignment = alignment
+    }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = textField.text
+        set(value) {
+            val setter = _accessibilitySetter ?: throw IllegalStateException("Select not bound")
+            setter(value ?: throw IllegalArgumentException("Cannot set null on Select"))
+        }
+
+    // by Claude - select supports click and setValue
+    override val accessibilityActions: Set<String> get() = setOf("click", "setValue")
+    override fun performAccessibilityAction(action: String, value: String?): String? = when (action) {
+        "click" -> null  // click is handled at the native level
+        "setValue" -> { accessibilityValue = value; null }
+        else -> super.performAccessibilityAction(action, value)
     }
 
     actual var enabled: Boolean

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/Slider.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/Slider.ios.kt
@@ -122,4 +122,12 @@ actual class Slider actual constructor(context: RContext) : RView(context) {
         native.maximumTrackTintColor = t.background.closestColor().toUiColor()
         native.thumbTintColor = t.foreground.closestColor().toUiColor()
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readNonNullValue(value)
+        set(v) = writeNonNullValue(value, v) { it.toFloatOrNull() ?: throw IllegalArgumentException("Cannot parse '$it' as Float") }
+    override val accessibilityActions get() = SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performNonNullSetValueAction(this.value, { it.toFloatOrNull() ?: throw IllegalArgumentException("Cannot parse '$it' as Float") }, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/SwapView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/SwapView.ios.kt
@@ -14,9 +14,11 @@ import com.lightningkite.kiteui.views.withoutAnimation
 
 
 actual class SwapView actual constructor(context: RContext): RView(context) {
-    
+
     override val native = FrameLayout()
     private var currentView: RView? = null
+    // by Claude - only expose the current (last) child for AI driver snapshots and path resolution
+    override val activeChildren: List<RView> get() = listOfNotNull(children.lastOrNull())
 
     init {
         native.clipsToBounds = true

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/Switch.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/Switch.ios.kt
@@ -1,9 +1,7 @@
 package com.lightningkite.kiteui.views.direct
 
 import com.lightningkite.kiteui.reactive.*
-import com.lightningkite.kiteui.views.RContext
-import com.lightningkite.kiteui.views.RView
-import com.lightningkite.kiteui.views.ViewDsl
+import com.lightningkite.kiteui.views.*
 import com.lightningkite.reactive.context.*
 import com.lightningkite.reactive.core.*
 import com.lightningkite.reactive.extensions.*
@@ -37,4 +35,12 @@ actual class Switch actual constructor(context: RContext) : RView(context) {
                     }
             }
         }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextArea.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextArea.ios.kt
@@ -97,8 +97,11 @@ actual class TextArea actual constructor(context: RContext) : RViewWithAction(co
         override var value: String
             get() = textField.text
             set(value) {
-                if(textField.text != value)
+                if(textField.text != value) {
                     textField.text = value
+                    // by Claude - notify listeners on programmatic updates (UITextView has no sendActionsForControlEvents)
+                    delegate.listeners.forEach { it() }
+                }
             }
         override fun addListener(listener: () -> Unit): () -> Unit {
             delegate.listeners.add(listener)
@@ -160,6 +163,14 @@ actual class TextArea actual constructor(context: RContext) : RViewWithAction(co
         if(native.focused) t = t[FocusSemantic]
         return super.applyState(t)
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }
 
 private class TextAreaDelegate() : NSObject(), UITextViewDelegateProtocol {

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextField.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextField.ios.kt
@@ -135,6 +135,8 @@ actual class TextInput actual constructor(context: RContext) : RViewWithAction(c
             set(value) {
                 if (textField.text == value) return
                 textField.text = value
+                // by Claude - fire change event so reactive listeners are notified on programmatic updates
+                textField.sendActionsForControlEvents(UIControlEventEditingChanged)
             }
     }
     actual var keyboardHints: KeyboardHints = KeyboardHints()
@@ -231,5 +233,13 @@ actual class TextInput actual constructor(context: RContext) : RViewWithAction(c
         if (textField.focused) t = t[FocusSemantic]
         return super.applyState(t)
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readStringValue(content)
+        set(value) = writeStringValue(content, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performStringSetValueAction(content, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }
 

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/TextView.ios.kt
@@ -162,6 +162,14 @@ actual class TextView actual constructor(context: RContext) : RView(context) {
         updateFont()
         native.linkSetup(html.contains("<a"))
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = content
+        set(value) { super.accessibilityValue = value }
+
+    // by Claude
+    override val accessibilityType: String get() = "Text"
 }
 
 // Calculated from font sizes shown at https://developer.apple.com/design/human-interface-guidelines/typography#Specifications

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ToggleButton.ios.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/ToggleButton.ios.kt
@@ -41,4 +41,12 @@ actual class ToggleButton actual constructor(context: RContext) : RView(context)
         if(native.focused) t = t[FocusSemantic]
         return super.applyState(t)
     }
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = readBooleanValue(checked)
+        set(value) = writeBooleanValue(checked, value)
+    override val accessibilityActions get() = CLICK_AND_SET_VALUE_ACTIONS
+    override fun performAccessibilityAction(action: String, value: String?) =
+        performBooleanAction(checked, action, value) { a, v -> super.performAccessibilityAction(a, v) }
 }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/UILabelWithGradient.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/UILabelWithGradient.kt
@@ -1,10 +1,8 @@
 package com.lightningkite.kiteui.views.direct
 
-import com.lightningkite.kiteui.ExternalServices
 import com.lightningkite.kiteui.WeakReference
 import com.lightningkite.kiteui.models.*
 import com.lightningkite.kiteui.objc.toObjcId
-import com.lightningkite.kiteui.openTab
 import com.lightningkite.kiteui.views.RContext
 import com.lightningkite.kiteui.views.debugPrint
 import com.lightningkite.kiteui.views.extensionPadding
@@ -156,8 +154,8 @@ class UILabelWithGradient : UIView(CGRectZero.readValue()) {
         val link = label.attributedText?.attribute(NSLinkAttributeName, indexOfCharacter, effectiveRange = null)
 
         when(link) {
-            is NSURL -> ExternalServices.openTab(link.toString())
-            is NSString -> ExternalServices.openTab(link as String)
+            is NSURL -> UIApplication.sharedApplication.openURL(link)
+            is NSString -> UIApplication.sharedApplication.openURL(NSURL(string = link as String))
         }
 
     }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/UILabelWithLayerBackground.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/direct/UILabelWithLayerBackground.kt
@@ -1,9 +1,7 @@
 package com.lightningkite.kiteui.views.direct
 
-import com.lightningkite.kiteui.ExternalServices
 import com.lightningkite.kiteui.WeakReference
 import com.lightningkite.kiteui.models.*
-import com.lightningkite.kiteui.openTab
 import com.lightningkite.kiteui.views.RContext
 import com.lightningkite.kiteui.views.debugPrint
 import com.lightningkite.kiteui.views.extensionPadding
@@ -103,8 +101,8 @@ class UILabelWithLayerBackground : UIView(CGRectZero.readValue()) {
         val link = label.attributedText?.attribute(NSLinkAttributeName, indexOfCharacter, effectiveRange = null)
 
         when(link) {
-            is NSURL -> ExternalServices.openTab(link.toString())
-            is NSString -> ExternalServices.openTab(link as String)
+            is NSURL -> UIApplication.sharedApplication.openURL(link)
+            is NSString -> UIApplication.sharedApplication.openURL(NSURL(string = link as String))
         }
 
     }

--- a/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/rootSetupIos.kt
+++ b/library/src/iosMain/kotlin/com/lightningkite/kiteui/views/rootSetupIos.kt
@@ -3,7 +3,6 @@
 package com.lightningkite.kiteui.views
 
 
-import com.lightningkite.kiteui.ExternalServices
 import com.lightningkite.kiteui.WeakReference
 import com.lightningkite.kiteui.afterTimeout
 import com.lightningkite.kiteui.models.*
@@ -56,7 +55,7 @@ class KeyboardObserver(val bottom: WeakReference<NSLayoutConstraint>, val view: 
             keyboardHeight - (view.get()?.window?.safeAreaInsets?.useContents { this.bottom } ?: 0.0)
 //            }
         afterTimeout((keyboardAnimationDuration * 1000.0).toLong()) {
-            view.get()?.findFirstResponderChild()?.scrollToMeCenter(true)
+            view.get()?.findFirstResponderChild()?.scrollToMe(true)
         }
     }
 

--- a/library/src/jsMain/kotlin/com/lightningkite/kiteui/root.kt
+++ b/library/src/jsMain/kotlin/com/lightningkite/kiteui/root.kt
@@ -23,9 +23,7 @@ import org.w3c.dom.Element
 fun root(theme: Theme, app: ViewWriter.()->Unit) {
     @OptIn(DelicateCoroutinesApi::class)
     object : ViewWriter(), CalculationContext by AppScope {
-        override val context: RContext = RContext(basePath).also {
-            ExternalServices.baseContext = it
-        }
+        override val context: RContext = RContext(basePath)
         override val representsView: RView? = null
 
         override fun willAddChild(view: RView) {
@@ -41,9 +39,7 @@ fun root(theme: Theme, app: ViewWriter.()->Unit) {
 fun root(theme: Reactive<Theme>, app: ViewWriter.()->Unit) {
     @OptIn(DelicateCoroutinesApi::class)
     object : ViewWriter(), CalculationContext by AppScope {
-        override val context: RContext = RContext(basePath).also {
-            ExternalServices.baseContext = it
-        }
+        override val context: RContext = RContext(basePath)
         override val representsView: RView? = null
 
         override fun willAddChild(view: RView) {
@@ -145,7 +141,6 @@ private fun hydrateRootInternal(
     // by Claude
     val rContext = RContext(basePath).apply {
         ssrDispatcher = Dispatchers.Unconfined
-        ExternalServices.baseContext = this  // Set consistently for both theme variants
     }
 
     // Track current child index for matching against SSR DOM

--- a/library/src/jvmSsrMain/kotlin/com/lightningkite/kiteui/ssr/SsrContext.kt
+++ b/library/src/jvmSsrMain/kotlin/com/lightningkite/kiteui/ssr/SsrContext.kt
@@ -113,6 +113,9 @@ class SsrContext(
     /** The rendered frame - stored for deferred serialization */
     private var renderedFrame: Frame? = null
 
+    /** The rendered root frame, for testing or inspection. */ // by Claude
+    val rootFrame: Frame? get() = renderedFrame
+
     /**
      * Render content using the ViewWriter DSL.
      * Builds the component tree but defers HTML serialization.

--- a/library/src/jvmSsrMain/kotlin/com/lightningkite/kiteui/views/direct/CircularProgress.jvm.kt
+++ b/library/src/jvmSsrMain/kotlin/com/lightningkite/kiteui/views/direct/CircularProgress.jvm.kt
@@ -8,4 +8,9 @@ actual class CircularProgress actual constructor(context: RContext) :
     actual var ratio: Float
         get() = TODO("Not yet implemented")
         set(value) {}
+
+    // by Claude
+    override var accessibilityValue: String?
+        get() = ratio.toString()
+        set(value) { super.accessibilityValue = value }
 }


### PR DESCRIPTION
## Summary
- **New accessibility API**: `ariaDescription`, `accessibilityType`, `accessibilityActions`, `accessibilityEnabled`, `accessibilityValue`, `performAccessibilityAction` on RViewHelper
- **AriaDescription modifier**: `ariaDescription` for labeling views, `String.toAiId()` for ID derivation, `resolveAiPath()` for path-based view lookup
- **Platform wiring**: 40+ view files across Android (contentDescription), iOS (accessibilityLabel), HTML (aria-label)
- **SwapView activeChildren**: Tracks visible content on all platforms
- **RViewWithAction/RViewWithSecondaryAction**: Default click/longClick accessibility actions

This PR provides standalone accessibility value and is also infrastructure consumed by the AI driver (PR #5).

## Test plan
- [ ] Run `./gradlew :library:compileKotlinJvmSsr` — verify compilation
- [ ] Run `./gradlew :library:jvmSsrTest` — verify existing tests pass
- [ ] Manual: verify Android TalkBack reads ariaDescription labels
- [ ] Manual: verify iOS VoiceOver reads accessibilityLabel

🤖 Generated with [Claude Code](https://claude.com/claude-code)