### PR TITLE
Fix AI driver test reliability: hidden view filtering, path consistency, reset command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## Unreleased
+
+### AI Driver / Test Utilities
+
+- **`find` and `findClickable` now filter hidden views by default.** Previously, both functions walked the entire view tree including pages hidden in `SwapView`/navigator stacks, causing tests to interact with stale off-screen views. Pass `includeHidden = true` (or the `--hidden` flag in raw commands) to restore the old behavior.
+
+- **`findAll()` paths now work directly with `click()`, `setValue()`, etc.** Previously, paths returned from `findAll()` on an anonymous (un-named) root had an extra `0/` prefix that misaligned with `resolveDriverPath`, requiring a workaround. Path construction now starts from the root's children so returned paths can be passed directly to any driver command.
+
+- **Added `reset` driver command.** Resets the navigator stack to a single page at the specified route, giving each test a clean known starting state. Available as `navigator.reset(route)` in `UiTestScope` and as the `reset` target in raw driver commands.
+
+- **Added `startRoute` parameter to `remoteUiTest()`.** Automatically calls `reset(startRoute)` before the test block when provided, so remote tests always start from a known page without manually calling `reset()`.
+
+- **`UiTestScope.find`, `findAll`, `findClickable`, `findWithAction`** each accept a new `includeHidden: Boolean = false` parameter.

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/DriverSupport.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/DriverSupport.kt
@@ -25,10 +25,11 @@ fun RView.driverSnapshot(options: RViewHelper.DriverSnapshotOptions = RViewHelpe
  * widget type (class name), or action names.
  * Returns a compact listing of matches with their display line.
  */
-fun RView.driverFind(query: String): String = buildString {
+fun RView.driverFind(query: String, includeHidden: Boolean = false): String = buildString {
     val baseActions = setOf("snapshot", "screenshot", "find", "findClickable", "scrollIntoView")
     val results = mutableListOf<Pair<String, RView>>()
     fun walk(view: RView, pathPrefix: String) {
+        if (!includeHidden && !(view.shown && view.visible)) return
         val segment = view.debugName ?: view.parent?.driverChildren?.indexOf(view)?.takeIf { it >= 0 }?.toString() ?: "0"
         // Named views reset the path prefix — resolveDriverPath deep-searches for the first
         // named segment, so the full ancestor chain is unnecessary. This keeps paths short
@@ -43,7 +44,9 @@ fun RView.driverFind(query: String): String = buildString {
         }
         for (child in view.driverChildren) walk(child, path)
     }
-    walk(this@driverFind, "")
+    // Start from root's children so returned paths align with resolveDriverPath's indexing.
+    // resolveDriverPath("0") means root.driverChildren[0], so paths must be relative to root's children.
+    for (child in this@driverFind.driverChildren) walk(child, "")
     if (results.isEmpty()) {
         append("No views matching '$query'")
     } else {
@@ -58,12 +61,13 @@ fun RView.driverFind(query: String): String = buildString {
  * the nearest ancestor with a "click" action. Returns deduplicated clickable ancestors
  * in the same format as [driverFind].
  */
-fun RView.driverFindClickable(query: String): String = buildString {
+fun RView.driverFindClickable(query: String, includeHidden: Boolean = false): String = buildString {
     val baseActions = setOf("snapshot", "screenshot", "find", "findClickable", "scrollIntoView")
     val viewPaths = mutableMapOf<RView, String>()
     val matches = mutableListOf<RView>()
 
     fun walk(view: RView, pathPrefix: String) {
+        if (!includeHidden && !(view.shown && view.visible)) return
         val segment = view.debugName ?: view.parent?.driverChildren?.indexOf(view)?.takeIf { it >= 0 }?.toString() ?: "0"
         val path = if (pathPrefix.isEmpty() || segment.toIntOrNull() == null) segment else "$pathPrefix/$segment"
         viewPaths[view] = path
@@ -76,7 +80,8 @@ fun RView.driverFindClickable(query: String): String = buildString {
         }
         for (child in view.driverChildren) walk(child, path)
     }
-    walk(this@driverFindClickable, "")
+    // Start from root's children so returned paths align with resolveDriverPath's indexing.
+    for (child in this@driverFindClickable.driverChildren) walk(child, "")
 
     val seen = mutableSetOf<RView>()
     val results = mutableListOf<Pair<String, RView>>()

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/RViewHelper.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/RViewHelper.kt
@@ -730,8 +730,8 @@ abstract class RViewHelper(override val context: RContext) : ViewWriter(), ViewP
     open val driverActions: Map<String, suspend (List<String>) -> String> get() = buildMap {
         put("snapshot") { args -> (this@RViewHelper as RView).driverSnapshot(parseSnapshotOptions(args.toTypedArray())) }
         put("screenshot") { (this@RViewHelper as RView).driverScreenshot() }
-        put("find") { args -> (this@RViewHelper as RView).driverFind(args.firstOrNull() ?: "") }
-        put("findClickable") { args -> (this@RViewHelper as RView).driverFindClickable(args.firstOrNull() ?: "") }
+        put("find") { args -> (this@RViewHelper as RView).driverFind(args.firstOrNull() ?: "", includeHidden = "--hidden" in args) }
+        put("findClickable") { args -> (this@RViewHelper as RView).driverFindClickable(args.firstOrNull() ?: "", includeHidden = "--hidden" in args) }
 //        put("scroll") { args ->
 //            // TODO: This looks wrong: in JS, the scrolling behaviors are just attached to an existing view in a way this wouldn't pick up
 //            val dx = args.getOrNull(0)?.toDoubleOrNull() ?: 0.0

--- a/library/src/jvmSsrTest/kotlin/com/lightningkite/kiteui/DriverTest.kt
+++ b/library/src/jvmSsrTest/kotlin/com/lightningkite/kiteui/DriverTest.kt
@@ -1035,4 +1035,69 @@ class DriverTest {
             assertIdExists("nonexistent")
         }
     }
+
+    // --- find visibility filtering ---
+
+    @Test
+    fun findExcludesHiddenViewsByDefault() = uiTest(
+        content = {
+            col {
+                textInput { debugName = "visible"; hint = "Visible" }
+                textInput { debugName = "hidden"; hint = "Hidden"; shown = false }
+            }
+        }
+    ) {
+        val results = findAll("TextInput")
+        assertTrue(results.any { it.name == "visible" }, "Should find visible input: $results")
+        assertTrue(results.none { it.name == "hidden" }, "Should not find hidden input by default: $results")
+
+        val allResults = findAll("TextInput", includeHidden = true)
+        assertTrue(allResults.any { it.name == "visible" }, "includeHidden should still show visible: $allResults")
+        assertTrue(allResults.any { it.name == "hidden" }, "includeHidden should show hidden input: $allResults")
+    }
+
+    @Test
+    fun findClickableExcludesHiddenByDefault() = uiTest(
+        content = {
+            col {
+                button { debugName = "visBtn"; text("Visible"); onClick { } }
+                button { debugName = "hidBtn"; text("Hidden"); onClick { }; shown = false }
+            }
+        }
+    ) {
+        val results = findClickable("Btn")
+        assertTrue(results.any { it.name == "visBtn" }, "Should find visible button: $results")
+        assertTrue(results.none { it.name == "hidBtn" }, "Should not find hidden button by default: $results")
+    }
+
+    // --- path consistency: findAll paths work directly with click ---
+
+    @Test
+    fun findPathsWorkDirectlyWithClick() = uiTest(
+        content = {
+            // No debugName on any container — tests that numeric paths from findAll are usable
+            col {
+                col {
+                    val counter = Signal(0)
+                    button {
+                        text("Go")
+                        onClick { counter.value++ }
+                    }
+                    text {
+                        debugName = "count"
+                        ::content { "Count: ${counter()}" }
+                    }
+                }
+            }
+        }
+    ) {
+        val results = findAll("Button")
+        assertTrue(results.isNotEmpty(), "Should find the Button: $results")
+        val buttonPath = results.first().path
+
+        // Path returned by findAll must work directly with click() without any fixup
+        click(buttonPath)
+        val snap = snapshot("count")
+        assertTrue(snap.contains("Count: 1"), "Click via findAll path should increment counter: $snap")
+    }
 }

--- a/test-utilities/src/commonMain/kotlin/com/lightningkite/kiteui/testing/UiTestScope.kt
+++ b/test-utilities/src/commonMain/kotlin/com/lightningkite/kiteui/testing/UiTestScope.kt
@@ -125,25 +125,36 @@ class UiTestScope(val backend: UiTestBackend) {
     suspend fun back(): String =
         backend.command(cmd("back", "back"))
 
-    /** Search the view tree for views matching a query. */
-    suspend fun find(query: String, target: String = "root"): String =
-        backend.command(cmd(target, "find", query))
+    /**
+     * Search the view tree for views matching a query.
+     * By default only visible views are searched; pass [includeHidden] to search the entire tree.
+     */
+    suspend fun find(query: String, target: String = "root", includeHidden: Boolean = false): String {
+        val command = if (includeHidden) cmd(target, "find", query, "--hidden") else cmd(target, "find", query)
+        return backend.command(command)
+    }
 
-    /** Search the view tree and return structured [FindResult]s. */
-    suspend fun findAll(query: String, target: String = "root"): List<FindResult> =
-        find(query, target).lines().filter { it.isNotBlank() }.mapNotNull { parseFindLine(it) }
+    /**
+     * Search the view tree and return structured [FindResult]s.
+     * By default only visible views are searched; pass [includeHidden] to search the entire tree.
+     */
+    suspend fun findAll(query: String, target: String = "root", includeHidden: Boolean = false): List<FindResult> =
+        find(query, target, includeHidden).lines().filter { it.isNotBlank() }.mapNotNull { parseFindLine(it) }
 
     /** Find the first view matching [query] that has the given [action]. */
-    suspend fun findWithAction(query: String, action: String, target: String = "root"): FindResult? =
-        findAll(query, target).firstOrNull { action in it.actions }
+    suspend fun findWithAction(query: String, action: String, target: String = "root", includeHidden: Boolean = false): FindResult? =
+        findAll(query, target, includeHidden).firstOrNull { action in it.actions }
 
     /**
      * Find views matching [query] and walk each up to the nearest clickable ancestor.
      * Returns deduplicated clickable views. Useful when `find("Login")` matches a Text
      * inside a Button — this returns the Button's path directly.
+     * By default only visible views are searched; pass [includeHidden] to search the entire tree.
      */
-    suspend fun findClickable(query: String, target: String = "root"): List<FindResult> =
-        backend.command(cmd(target, "findClickable", query)).lines().filter { it.isNotBlank() }.mapNotNull { parseFindLine(it) }
+    suspend fun findClickable(query: String, target: String = "root", includeHidden: Boolean = false): List<FindResult> {
+        val command = if (includeHidden) cmd(target, "findClickable", query, "--hidden") else cmd(target, "findClickable", query)
+        return backend.command(command).lines().filter { it.isNotBlank() }.mapNotNull { parseFindLine(it) }
+    }
 
     /** Get recent log entries. */
     suspend fun logs(count: Int = 50): String =

--- a/test-utilities/src/jvmSsrMain/kotlin/com/lightningkite/kiteui/testing/RemoteUiTest.kt
+++ b/test-utilities/src/jvmSsrMain/kotlin/com/lightningkite/kiteui/testing/RemoteUiTest.kt
@@ -5,14 +5,21 @@ import kotlinx.coroutines.runBlocking
 /**
  * Runs a UI test against a remote app connected to the AI driver daemon.
  * Same [UiTestScope] API as local tests — tests work identically local or remote.
+ *
+ * @param startRoute If provided, resets the navigator stack to this route before running the test,
+ *   giving every test a clean known starting state regardless of what prior tests did.
  */
 fun remoteUiTest(
     appId: String,
     host: String = "127.0.0.1",
     port: Int = 7474,
+    startRoute: String? = null,
     block: suspend UiTestScope.() -> Unit,
 ) {
     val backend = RemoteUiTestBackend(appId, host, port)
     val scope = UiTestScope(backend)
-    runBlocking { scope.block() }
+    runBlocking {
+        if (startRoute != null) scope.reset(startRoute)
+        scope.block()
+    }
 }


### PR DESCRIPTION
## Summary

- **Hidden view filtering**: `find` and `findClickable` now skip views where `shown == false || visible == false` by default, eliminating stale-page contamination from SwapView/navigator stacks. Pass `includeHidden = true` (or `--hidden` flag) to opt in to the old behavior.
- **Path consistency fix**: `findAll()` paths now align correctly with `resolveDriverPath`. Previously, starting the walk at the root view itself added an off-by-one level to all numeric paths, meaning paths from `findAll()` couldn't be passed directly to `click()` without a stripping workaround. Walk now starts at root's children.
- **`reset` driver command**: Clears the navigator stack to a single page at the specified route. Enables clean per-test state. Ported from `worktree-otel-integration`.
- **`startRoute` for `remoteUiTest()`**: Automatically calls `reset(startRoute)` before the test block so remote tests always start from a known page.
- **`includeHidden` param** added to `find`, `findAll`, `findClickable`, `findWithAction` in `UiTestScope`.

## Test plan

- [x] `./gradlew :library:jvmSsrTest --tests "*.DriverTest"` — all existing tests pass
- [x] New `findExcludesHiddenViewsByDefault` — verifies hidden views are filtered
- [x] New `findClickableExcludesHiddenByDefault` — same for findClickable
- [x] New `findPathsWorkDirectlyWithClick` — verifies path consistency fix end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)