### PR TITLE
Fixes for picme (iosx64 and label fix)

### DIFF
--- a/library-camera/build.gradle.kts
+++ b/library-camera/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
     if (onMac) {
         iosArm64()
         iosSimulatorArm64()
+        iosX64()
     }
     js(IR) {
         browser()

--- a/library-lottie/build.gradle.kts
+++ b/library-lottie/build.gradle.kts
@@ -32,6 +32,7 @@ kotlin {
     if (onMac) {
         iosArm64()
         iosSimulatorArm64()
+        iosX64()
     }
     js(IR) {
         browser()

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
     if (iosTarget) {
         iosArm64()
         iosSimulatorArm64()
+        iosX64()
     }
     js(IR) {
         browser {

--- a/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/l2/labels.kt
+++ b/library/src/commonMain/kotlin/com/lightningkite/kiteui/views/l2/labels.kt
@@ -47,6 +47,7 @@ class LabeledView(private val container: RowOrCol): LinearLayoutElement by conta
     @OverrideOnly
     override fun onStartup() {
         container.onStartup()
+        container.vertical= true
         val target = findFirstInteractiveDescendant()
         if (target != null) {
             label.labelFor = target

--- a/test-utilities/build.gradle.kts
+++ b/test-utilities/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
     if (iosTarget) {
         iosArm64()
         iosSimulatorArm64()
+        iosX64()
     }
     js(IR) {
         browser()


### PR DESCRIPTION
add iosX64 back in to be able to build ios apps on x86 macs. fix labels showing label and text field in a row instead of a column like the other platforms