### PR TITLE
foreground process visual state change for android & web

### DIFF
--- a/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Button.android.kt
+++ b/library/src/androidMain/kotlin/com/lightningkite/kiteui/views/direct/Button.android.kt
@@ -28,7 +28,7 @@ actual class Button actual constructor(context: ElementContext): NativeContainer
         addChild(object: NativeElement(context) {
             override val native = this@Button.progress
         })
-        foregroundProcesses.addListener { progress.visibility = if(!foregroundProcesses.state.success) View.VISIBLE else View.GONE }
+        foregroundProcesses.addListener { progress.visibility = if(!foregroundProcesses.state.ready) View.VISIBLE else View.GONE }
     }
 
     override fun nativeApplyTheme(theme: ThemeAndBack) {

--- a/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/NativeElement.commonHtml.kt
+++ b/library/src/commonHtmlMain/kotlin/com/lightningkite/kiteui/views/NativeElement.commonHtml.kt
@@ -190,7 +190,7 @@ actual abstract class NativeElement actual constructor(context: ElementContext) 
 
     init {
         foregroundProcesses.addListener {   // auto-released when view is removed
-            if (!foregroundProcesses.state.success) native.classes.add("working")
+            if (!foregroundProcesses.state.ready) native.classes.add("working")
             else native.classes.remove("working")
         }
     }


### PR DESCRIPTION
In web, if an exception is thrown, the button remains in a "working" visual state (with loading spinner)